### PR TITLE
P0: Model Validation and Registry Enforcement

### DIFF
--- a/test/knowledge-edge-cases.test.ts
+++ b/test/knowledge-edge-cases.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { InMemoryKnowledgeStore } from '../src/knowledge/store';
 import { KnowledgeScopeContext } from '../src/types';
+import { createModelRegistry } from '../src/models';
 
 describe('KnowledgeStore Edge Cases and Race Conditions', () => {
   let store: InMemoryKnowledgeStore;
   const globalScope: KnowledgeScopeContext = { scope: 'global' };
 
+  // Use real model IDs from the registry
+  const modelA = 'claude-3-5-sonnet';
+  const modelB = 'gpt-4o';
+  const modelC = 'gemini-1.5-pro';
+
   beforeEach(async () => {
-    store = new InMemoryKnowledgeStore();
+    const modelRegistry = createModelRegistry();
+    store = new InMemoryKnowledgeStore(modelRegistry);
   });
 
   describe('Division by Zero and NaN Prevention', () => {
@@ -19,7 +26,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
     it('should handle agreement calculation with zero total votes', async () => {
       // Create entry with one vote
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
       const entry = await store.get('test', globalScope);
 
       // Verify no NaN or Infinity
@@ -31,7 +38,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
   describe('Floating Point Precision', () => {
     it('should handle fractional votes after decay without precision errors', async () => {
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
 
       // Apply many decay cycles
       for (let i = 0; i < 50; i++) {
@@ -52,9 +59,9 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
     it('should maintain agreement score between 0 and 1', async () => {
       // Record votes with various distributions
-      await store.recordVote('test1', 'model-a', globalScope);
-      await store.recordVote('test1', 'model-a', globalScope);
-      await store.recordVote('test1', 'model-b', globalScope);
+      await store.recordVote('test1', modelA, globalScope);
+      await store.recordVote('test1', modelA, globalScope);
+      await store.recordVote('test1', modelB, globalScope);
 
       await store.applyDecay();
       await store.applyDecay();
@@ -66,7 +73,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should handle very small vote counts after extensive decay', async () => {
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
 
       // Extreme decay
       for (let i = 0; i < 200; i++) {
@@ -76,8 +83,8 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
       const entry = await store.get('test', globalScope);
 
       // Should enforce minimum values to prevent underflow
-      expect(entry!.model_votes['model-a']).toBeGreaterThan(0);
-      expect(entry!.model_votes['model-a']).toBeGreaterThanOrEqual(0.001);
+      expect(entry!.model_votes[modelA]).toBeGreaterThan(0);
+      expect(entry!.model_votes[modelA]).toBeGreaterThanOrEqual(0.001);
       expect(entry!.decay_factor).toBeGreaterThanOrEqual(0.01);
     });
   });
@@ -98,23 +105,23 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
     it('should handle concurrent votes for different models in same cluster', async () => {
       const promises = [
-        ...Array.from({ length: 60 }, () => store.recordVote('coding', 'model-a', globalScope)),
-        ...Array.from({ length: 40 }, () => store.recordVote('coding', 'model-b', globalScope)),
+        ...Array.from({ length: 60 }, () => store.recordVote('coding', modelA, globalScope)),
+        ...Array.from({ length: 40 }, () => store.recordVote('coding', modelB, globalScope)),
       ];
 
       await Promise.all(promises);
 
       const entry = await store.get('coding', globalScope);
       expect(entry!.total_votes).toBe(100);
-      expect(entry!.model_votes['model-a']).toBe(60);
-      expect(entry!.model_votes['model-b']).toBe(40);
+      expect(entry!.model_votes[modelA]).toBe(60);
+      expect(entry!.model_votes[modelB]).toBe(40);
       expect(entry!.agreement_score).toBe(0.6); // 60/100
     });
 
     it('should handle concurrent votes across multiple clusters', async () => {
       const clusters = ['coding', 'legal', 'creative', 'reasoning'];
       const promises = clusters.flatMap(cluster =>
-        Array.from({ length: 10 }, () => store.recordVote(cluster, 'model-a', globalScope))
+        Array.from({ length: 10 }, () => store.recordVote(cluster, modelA, globalScope))
       );
 
       await Promise.all(promises);
@@ -127,7 +134,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
     it('should handle concurrent decay operations', async () => {
       // Set up initial data
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
 
       // Run multiple decay operations concurrently
       const promises = Array.from({ length: 5 }, () => store.applyDecay());
@@ -139,7 +146,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
       const entry = await store.get('test', globalScope);
       // Entry should still exist
       expect(entry).not.toBeNull();
-      expect(entry!.model_votes['model-a']).toBeGreaterThan(0);
+      expect(entry!.model_votes[modelA]).toBeGreaterThan(0);
     });
   });
 
@@ -152,10 +159,10 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
       const votesAgainst = minVotes - votesFor;
 
       for (let i = 0; i < votesFor; i++) {
-        await store.recordVote('test', 'model-a', globalScope);
+        await store.recordVote('test', modelA, globalScope);
       }
       for (let i = 0; i < votesAgainst; i++) {
-        await store.recordVote('test', 'model-b', globalScope);
+        await store.recordVote('test', modelB, globalScope);
       }
 
       const entry = await store.get('test', globalScope);
@@ -169,10 +176,10 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle exact boundary at 0.6 agreement', async () => {
       // 6 votes for A, 4 for B = exactly 60%
       for (let i = 0; i < 6; i++) {
-        await store.recordVote('test', 'model-a', globalScope);
+        await store.recordVote('test', modelA, globalScope);
       }
       for (let i = 0; i < 4; i++) {
-        await store.recordVote('test', 'model-b', globalScope);
+        await store.recordVote('test', modelB, globalScope);
       }
 
       const entry = await store.get('test', globalScope);
@@ -185,10 +192,10 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle just below 0.6 agreement', async () => {
       // 59% agreement
       for (let i = 0; i < 59; i++) {
-        await store.recordVote('test', 'model-a', globalScope);
+        await store.recordVote('test', modelA, globalScope);
       }
       for (let i = 0; i < 41; i++) {
-        await store.recordVote('test', 'model-b', globalScope);
+        await store.recordVote('test', modelB, globalScope);
       }
 
       const entry = await store.get('test', globalScope);
@@ -200,7 +207,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle transition from strong to moderate after decay', async () => {
       // Build strong confidence
       for (let i = 0; i < 10; i++) {
-        await store.recordVote('test', 'model-a', globalScope);
+        await store.recordVote('test', modelA, globalScope);
       }
 
       let entry = await store.get('test', globalScope);
@@ -222,9 +229,9 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
   describe('Model Vote Distribution Edge Cases', () => {
     it('should handle three-way tie', async () => {
-      await store.recordVote('test', 'model-a', globalScope);
-      await store.recordVote('test', 'model-b', globalScope);
-      await store.recordVote('test', 'model-c', globalScope);
+      await store.recordVote('test', modelA, globalScope);
+      await store.recordVote('test', modelB, globalScope);
+      await store.recordVote('test', modelC, globalScope);
 
       const entry = await store.get('test', globalScope);
 
@@ -233,20 +240,26 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should handle many models with one vote each', async () => {
-      for (let i = 0; i < 20; i++) {
-        await store.recordVote('test', `model-${i}`, globalScope);
+      const modelRegistry = createModelRegistry();
+      const availableModels = modelRegistry.getAvailableModels().map(m => m.id);
+
+      // Record one vote for each available model
+      for (const modelId of availableModels) {
+        await store.recordVote('test', modelId, globalScope);
       }
 
       const entry = await store.get('test', globalScope);
 
-      expect(entry!.agreement_score).toBeCloseTo(0.05, 2); // 1/20
+      // Agreement score should be 1 / number_of_models
+      const expectedAgreement = 1 / availableModels.length;
+      expect(entry!.agreement_score).toBeCloseTo(expectedAgreement, 2);
       expect(entry!.confidence_level).toBe('low');
-      expect(Object.keys(entry!.model_votes).length).toBe(20);
+      expect(Object.keys(entry!.model_votes).length).toBe(availableModels.length);
     });
 
     it('should handle extreme agreement (100%)', async () => {
       for (let i = 0; i < 100; i++) {
-        await store.recordVote('test', 'model-a', globalScope);
+        await store.recordVote('test', modelA, globalScope);
       }
 
       const entry = await store.get('test', globalScope);
@@ -257,8 +270,8 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
     it('should handle complete disagreement (50-50)', async () => {
       for (let i = 0; i < 50; i++) {
-        await store.recordVote('test', 'model-a', globalScope);
-        await store.recordVote('test', 'model-b', globalScope);
+        await store.recordVote('test', modelA, globalScope);
+        await store.recordVote('test', modelB, globalScope);
       }
 
       const entry = await store.get('test', globalScope);
@@ -270,7 +283,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
   describe('Consensus Model Selection Edge Cases', () => {
     it('should return null when confidence is low even with votes', async () => {
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
 
       const consensus = await store.getConsensusModel('test', globalScope);
 
@@ -280,8 +293,8 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle tie-breaking (first alphabetically or highest in iteration order)', async () => {
       // Create exact tie with moderate confidence
       for (let i = 0; i < 5; i++) {
-        await store.recordVote('test', 'model-a', globalScope);
-        await store.recordVote('test', 'model-b', globalScope);
+        await store.recordVote('test', modelA, globalScope);
+        await store.recordVote('test', modelB, globalScope);
       }
 
       const consensus = await store.getConsensusModel('test', globalScope);
@@ -293,20 +306,20 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle consensus model selection after decay', async () => {
       // Strong initial consensus
       for (let i = 0; i < 8; i++) {
-        await store.recordVote('test', 'model-a', globalScope);
+        await store.recordVote('test', modelA, globalScope);
       }
       for (let i = 0; i < 2; i++) {
-        await store.recordVote('test', 'model-b', globalScope);
+        await store.recordVote('test', modelB, globalScope);
       }
 
       const beforeDecay = await store.getConsensusModel('test', globalScope);
-      expect(beforeDecay).toBe('model-a');
+      expect(beforeDecay).toBe(modelA);
 
       await store.applyDecay();
 
       const afterDecay = await store.getConsensusModel('test', globalScope);
       // Proportions stay same, so consensus should remain
-      expect(afterDecay).toBe('model-a');
+      expect(afterDecay).toBe(modelA);
     });
 
     it('should return null for non-existent cluster', async () => {
@@ -327,7 +340,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should calculate average agreement correctly with one entry', async () => {
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
 
       const stats = await store.getStats();
 
@@ -338,7 +351,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle all entries at same confidence level', async () => {
       // Create 5 low confidence entries
       for (let i = 0; i < 5; i++) {
-        await store.recordVote(`cluster-${i}`, 'model-a', globalScope);
+        await store.recordVote(`cluster-${i}`, modelA, globalScope);
       }
 
       const stats = await store.getStats();
@@ -351,7 +364,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
   describe('Decay Factor Edge Cases', () => {
     it('should never decay below minimum threshold', async () => {
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
 
       // Apply extreme decay
       for (let i = 0; i < 1000; i++) {
@@ -365,7 +378,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should maintain decay_factor as multiplicative', async () => {
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
 
       const initial = await store.get('test', globalScope);
       const initialFactor = initial!.decay_factor;
@@ -382,7 +395,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
   describe('Special Intent Cluster Names', () => {
     it('should handle empty string cluster name', async () => {
-      await store.recordVote('', 'model-a', globalScope);
+      await store.recordVote('', modelA, globalScope);
 
       const entry = await store.get('', globalScope);
       expect(entry).not.toBeNull();
@@ -392,7 +405,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle very long cluster names', async () => {
       const longName = 'a'.repeat(10000);
 
-      await store.recordVote(longName, 'model-a', globalScope);
+      await store.recordVote(longName, modelA, globalScope);
 
       const entry = await store.get(longName, globalScope);
       expect(entry).not.toBeNull();
@@ -402,7 +415,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle cluster names with special characters', async () => {
       const special = 'cluster-with-!@#$%^&*()-special';
 
-      await store.recordVote(special, 'model-a', globalScope);
+      await store.recordVote(special, modelA, globalScope);
 
       const entry = await store.get(special, globalScope);
       expect(entry).not.toBeNull();
@@ -411,7 +424,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     it('should handle unicode cluster names', async () => {
       const unicode = '编程-意图-🎯';
 
-      await store.recordVote(unicode, 'model-a', globalScope);
+      await store.recordVote(unicode, modelA, globalScope);
 
       const entry = await store.get(unicode, globalScope);
       expect(entry).not.toBeNull();
@@ -421,9 +434,9 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
   describe('Clear Operation', () => {
     it('should remove all entries', async () => {
-      await store.recordVote('cluster1', 'model-a', globalScope);
-      await store.recordVote('cluster2', 'model-b', globalScope);
-      await store.recordVote('cluster3', 'model-c', globalScope);
+      await store.recordVote('cluster1', modelA, globalScope);
+      await store.recordVote('cluster2', modelB, globalScope);
+      await store.recordVote('cluster3', modelC, globalScope);
 
       await store.clear();
 
@@ -443,14 +456,14 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should allow new votes after clear', async () => {
-      await store.recordVote('test', 'model-a', globalScope);
+      await store.recordVote('test', modelA, globalScope);
       await store.clear();
-      await store.recordVote('test', 'model-b', globalScope);
+      await store.recordVote('test', modelB, globalScope);
 
       const entry = await store.get('test', globalScope);
       expect(entry).not.toBeNull();
-      expect(entry!.model_votes['model-b']).toBe(1);
-      expect(entry!.model_votes['model-a']).toBeUndefined();
+      expect(entry!.model_votes[modelB]).toBe(1);
+      expect(entry!.model_votes[modelA]).toBeUndefined();
     });
   });
 });

--- a/test/knowledge-scope.test.ts
+++ b/test/knowledge-scope.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { InMemoryKnowledgeStore } from '../src/knowledge/store';
 import { KnowledgeScopeContext } from '../src/types';
+import { createModelRegistry } from '../src/models';
 
 describe('Knowledge Scope', () => {
   let knowledgeStore: InMemoryKnowledgeStore;
 
+  // Use real model IDs from the registry
+  const modelA = 'claude-3-5-sonnet';
+  const modelB = 'gpt-4o';
+
   beforeEach(() => {
-    knowledgeStore = new InMemoryKnowledgeStore();
+    const modelRegistry = createModelRegistry();
+    knowledgeStore = new InMemoryKnowledgeStore(modelRegistry);
   });
 
   describe('Global Scope (Default)', () => {

--- a/test/knowledge.test.ts
+++ b/test/knowledge.test.ts
@@ -1,23 +1,30 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { InMemoryKnowledgeStore } from '../src/knowledge/store';
 import { KnowledgeScopeContext } from '../src/types';
+import { createModelRegistry } from '../src/models';
 
 describe('KnowledgeStore', () => {
   let store: InMemoryKnowledgeStore;
   const globalScope: KnowledgeScopeContext = { scope: 'global' };
 
+  // Use real model IDs from the registry
+  const modelA = 'claude-3-5-sonnet';
+  const modelB = 'gpt-4o';
+  const modelC = 'gemini-1.5-pro';
+
   beforeEach(async () => {
-    store = new InMemoryKnowledgeStore();
+    const modelRegistry = createModelRegistry();
+    store = new InMemoryKnowledgeStore(modelRegistry);
   });
 
   describe('Agreement Score Calculation', () => {
     it('should calculate agreement_score as max_votes / total_votes', async () => {
       // Record 8 votes for model A, 2 for model B
       for (let i = 0; i < 8; i++) {
-        await store.recordVote('coding', 'model-a', globalScope);
+        await store.recordVote('coding', modelA, globalScope);
       }
       for (let i = 0; i < 2; i++) {
-        await store.recordVote('coding', 'model-b', globalScope);
+        await store.recordVote('coding', modelB, globalScope);
       }
 
       const entry = await store.get('coding', globalScope);
@@ -27,9 +34,9 @@ describe('KnowledgeStore', () => {
     });
 
     it('should return 1.0 agreement when only one model has votes', async () => {
-      await store.recordVote('coding', 'model-a', globalScope);
-      await store.recordVote('coding', 'model-a', globalScope);
-      await store.recordVote('coding', 'model-a', globalScope);
+      await store.recordVote('coding', modelA, globalScope);
+      await store.recordVote('coding', modelA, globalScope);
+      await store.recordVote('coding', modelA, globalScope);
 
       const entry = await store.get('coding', globalScope);
 
@@ -37,8 +44,8 @@ describe('KnowledgeStore', () => {
     });
 
     it('should handle equal distribution (disagreement)', async () => {
-      await store.recordVote('coding', 'model-a', globalScope);
-      await store.recordVote('coding', 'model-b', globalScope);
+      await store.recordVote('coding', modelA, globalScope);
+      await store.recordVote('coding', modelB, globalScope);
 
       const entry = await store.get('coding', globalScope);
 
@@ -50,7 +57,7 @@ describe('KnowledgeStore', () => {
     it('should assign strong confidence when agreement >= 0.8 with enough votes', async () => {
       // 10 votes for same model = 100% agreement
       for (let i = 0; i < 10; i++) {
-        await store.recordVote('coding', 'model-a', globalScope);
+        await store.recordVote('coding', modelA, globalScope);
       }
 
       const entry = await store.get('coding', globalScope);
@@ -61,10 +68,10 @@ describe('KnowledgeStore', () => {
     it('should assign moderate confidence when agreement >= 0.6', async () => {
       // 7 votes for A, 3 for B = 70% agreement
       for (let i = 0; i < 7; i++) {
-        await store.recordVote('coding', 'model-a', globalScope);
+        await store.recordVote('coding', modelA, globalScope);
       }
       for (let i = 0; i < 3; i++) {
-        await store.recordVote('coding', 'model-b', globalScope);
+        await store.recordVote('coding', modelB, globalScope);
       }
 
       const entry = await store.get('coding', globalScope);
@@ -76,13 +83,13 @@ describe('KnowledgeStore', () => {
     it('should assign low confidence when agreement < 0.6', async () => {
       // 3 votes for A, 3 for B, 2 for C = 37.5% agreement
       for (let i = 0; i < 3; i++) {
-        await store.recordVote('coding', 'model-a', globalScope);
+        await store.recordVote('coding', modelA, globalScope);
       }
       for (let i = 0; i < 3; i++) {
-        await store.recordVote('coding', 'model-b', globalScope);
+        await store.recordVote('coding', modelB, globalScope);
       }
       for (let i = 0; i < 2; i++) {
-        await store.recordVote('coding', 'model-c', globalScope);
+        await store.recordVote('coding', modelC, globalScope);
       }
 
       const entry = await store.get('coding', globalScope);
@@ -93,8 +100,8 @@ describe('KnowledgeStore', () => {
 
     it('should require minimum votes for strong confidence', async () => {
       // High agreement but only 2 votes
-      await store.recordVote('coding', 'model-a', globalScope);
-      await store.recordVote('coding', 'model-a', globalScope);
+      await store.recordVote('coding', modelA, globalScope);
+      await store.recordVote('coding', modelA, globalScope);
 
       const entry = await store.get('coding', globalScope);
 
@@ -108,7 +115,7 @@ describe('KnowledgeStore', () => {
     it('should reduce vote counts on decay', async () => {
       // Initial votes
       for (let i = 0; i < 10; i++) {
-        await store.recordVote('coding', 'model-a', globalScope);
+        await store.recordVote('coding', modelA, globalScope);
       }
 
       const before = await store.get('coding', globalScope);
@@ -122,7 +129,7 @@ describe('KnowledgeStore', () => {
     });
 
     it('should never delete entries on decay', async () => {
-      await store.recordVote('coding', 'model-a', globalScope);
+      await store.recordVote('coding', modelA, globalScope);
 
       // Apply many decay cycles
       for (let i = 0; i < 100; i++) {
@@ -133,11 +140,11 @@ describe('KnowledgeStore', () => {
 
       // Entry should still exist
       expect(entry).not.toBeNull();
-      expect(entry!.model_votes['model-a']).toBeGreaterThan(0);
+      expect(entry!.model_votes[modelA]).toBeGreaterThan(0);
     });
 
     it('should reduce decay_factor over time', async () => {
-      await store.recordVote('coding', 'model-a', globalScope);
+      await store.recordVote('coding', modelA, globalScope);
       const before = await store.get('coding', globalScope);
 
       await store.applyDecay();
@@ -149,21 +156,21 @@ describe('KnowledgeStore', () => {
     it('should maintain relative vote proportions after decay', async () => {
       // 8 votes for A, 2 for B
       for (let i = 0; i < 8; i++) {
-        await store.recordVote('coding', 'model-a', globalScope);
+        await store.recordVote('coding', modelA, globalScope);
       }
       for (let i = 0; i < 2; i++) {
-        await store.recordVote('coding', 'model-b', globalScope);
+        await store.recordVote('coding', modelB, globalScope);
       }
 
       const before = await store.get('coding', globalScope);
       const ratioBefore =
-        before!.model_votes['model-a']! / before!.model_votes['model-b']!;
+        before!.model_votes[modelA]! / before!.model_votes[modelB]!;
 
       await store.applyDecay();
 
       const after = await store.get('coding', globalScope);
       const ratioAfter =
-        after!.model_votes['model-a']! / after!.model_votes['model-b']!;
+        after!.model_votes[modelA]! / after!.model_votes[modelB]!;
 
       // Ratio should remain approximately the same
       expect(Math.abs(ratioBefore - ratioAfter)).toBeLessThan(0.01);
@@ -173,20 +180,20 @@ describe('KnowledgeStore', () => {
   describe('Consensus Model Selection', () => {
     it('should return model with most votes as consensus', async () => {
       for (let i = 0; i < 7; i++) {
-        await store.recordVote('coding', 'model-a', globalScope);
+        await store.recordVote('coding', modelA, globalScope);
       }
       for (let i = 0; i < 3; i++) {
-        await store.recordVote('coding', 'model-b', globalScope);
+        await store.recordVote('coding', modelB, globalScope);
       }
 
       const consensus = await store.getConsensusModel('coding', globalScope);
 
-      expect(consensus).toBe('model-a');
+      expect(consensus).toBe(modelA);
     });
 
     it('should return null for low confidence entries', async () => {
       // Only 1 vote = low confidence
-      await store.recordVote('coding', 'model-a', globalScope);
+      await store.recordVote('coding', modelA, globalScope);
 
       const consensus = await store.getConsensusModel('coding', globalScope);
 
@@ -204,19 +211,19 @@ describe('KnowledgeStore', () => {
     it('should track entries by confidence level', async () => {
       // Create strong confidence entry
       for (let i = 0; i < 10; i++) {
-        await store.recordVote('strong-intent', 'model-a', globalScope);
+        await store.recordVote('strong-intent', modelA, globalScope);
       }
 
       // Create moderate confidence entry
       for (let i = 0; i < 7; i++) {
-        await store.recordVote('moderate-intent', 'model-a', globalScope);
+        await store.recordVote('moderate-intent', modelA, globalScope);
       }
       for (let i = 0; i < 3; i++) {
-        await store.recordVote('moderate-intent', 'model-b', globalScope);
+        await store.recordVote('moderate-intent', modelB, globalScope);
       }
 
       // Create low confidence entry
-      await store.recordVote('low-intent', 'model-a', globalScope);
+      await store.recordVote('low-intent', modelA, globalScope);
 
       const stats = await store.getStats();
 
@@ -229,12 +236,12 @@ describe('KnowledgeStore', () => {
     it('should calculate average agreement score', async () => {
       // Entry 1: 100% agreement
       for (let i = 0; i < 5; i++) {
-        await store.recordVote('intent-1', 'model-a', globalScope);
+        await store.recordVote('intent-1', modelA, globalScope);
       }
 
       // Entry 2: 50% agreement
-      await store.recordVote('intent-2', 'model-a', globalScope);
-      await store.recordVote('intent-2', 'model-b', globalScope);
+      await store.recordVote('intent-2', modelA, globalScope);
+      await store.recordVote('intent-2', modelB, globalScope);
 
       const stats = await store.getStats();
 

--- a/test/routing-edge-cases.test.ts
+++ b/test/routing-edge-cases.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { DefaultRoutingEngine } from '../src/routing/engine';
 import { InMemoryKnowledgeStore } from '../src/knowledge/store';
 import { HeuristicIntentClassifier } from '../src/intent/classifier';
+import { createModelRegistry } from '../src/models';
 import { DefaultPolicyEngine } from '../src/policy/engine';
 import { DefaultModelRegistry } from '../src/models/registry';
 import { TokenConfig, PolicyRule, RouteRequest, KnowledgeScopeContext } from '../src/types';
@@ -9,6 +10,10 @@ import { TokenConfig, PolicyRule, RouteRequest, KnowledgeScopeContext } from '..
 describe('RoutingEngine Edge Cases and Security', () => {
   let routingEngine: DefaultRoutingEngine;
   let knowledgeStore: InMemoryKnowledgeStore;
+
+  // Use real model IDs from the registry
+  const modelA = 'claude-3-5-sonnet';
+  const modelB = 'gpt-4o';
   const globalScope: KnowledgeScopeContext = { scope: 'global' };
   let intentClassifier: HeuristicIntentClassifier;
   let policyEngine: DefaultPolicyEngine;
@@ -26,10 +31,10 @@ describe('RoutingEngine Edge Cases and Security', () => {
   }
 
   beforeEach(async () => {
-    knowledgeStore = new InMemoryKnowledgeStore();
+    modelRegistry = createModelRegistry();
+    knowledgeStore = new InMemoryKnowledgeStore(modelRegistry);
     intentClassifier = new HeuristicIntentClassifier();
     policyEngine = new DefaultPolicyEngine();
-    modelRegistry = new DefaultModelRegistry();
 
     routingEngine = new DefaultRoutingEngine({
       intentClassifier,

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { DefaultRoutingEngine } from '../src/routing/engine';
 import { InMemoryKnowledgeStore } from '../src/knowledge/store';
 import { HeuristicIntentClassifier } from '../src/intent/classifier';
+import { createModelRegistry } from '../src/models';
 import { DefaultPolicyEngine } from '../src/policy/engine';
 import { DefaultModelRegistry } from '../src/models/registry';
 import { TokenConfig, PolicyRule, KnowledgeScopeContext } from '../src/types';
@@ -9,6 +10,10 @@ import { TokenConfig, PolicyRule, KnowledgeScopeContext } from '../src/types';
 describe('RoutingEngine', () => {
   let routingEngine: DefaultRoutingEngine;
   let knowledgeStore: InMemoryKnowledgeStore;
+
+  // Use real model IDs from the registry
+  const modelA = 'claude-3-5-sonnet';
+  const modelB = 'gpt-4o';
   const globalScope: KnowledgeScopeContext = { scope: 'global' };
   let intentClassifier: HeuristicIntentClassifier;
   let policyEngine: DefaultPolicyEngine;
@@ -26,10 +31,10 @@ describe('RoutingEngine', () => {
   }
 
   beforeEach(async () => {
-    knowledgeStore = new InMemoryKnowledgeStore();
+    modelRegistry = createModelRegistry();
+    knowledgeStore = new InMemoryKnowledgeStore(modelRegistry);
     intentClassifier = new HeuristicIntentClassifier();
     policyEngine = new DefaultPolicyEngine();
-    modelRegistry = new DefaultModelRegistry();
 
     routingEngine = new DefaultRoutingEngine({
       intentClassifier,


### PR DESCRIPTION
## Summary
Implements Model Validation and Registry Enforcement as a foundational correctness feature for Wayfinder. This prevents data corruption, enforces determinism, and protects the knowledge store from invalid model identifiers.

## Core Design Principles
- **Fail-fast validation**: No silent coercion, aliasing, or fallback
- **Single source of truth**: ModelRegistry is authoritative for valid model IDs
- **Global eligibility**: Models can be restricted from global knowledge scope
- **Lifecycle states**: active (works), deprecated (works but warns), disabled (rejected)

## Validation Enforcement Points
Model validation is enforced at ALL ingestion points:

```
Token Config → validateTokenConfig()
   ├─ trusted_anchor_model
   ├─ default_model
   ├─ allowed_models[]
   └─ denied_models[]

Feedback → assertModelExists() + assertModelActive() + assertModelAllowedForToken()
   ├─ selected_model
   └─ preferred_model

Knowledge Store → assertModelExists() + assertModelActive() + assertModelGlobalEligible()
   └─ model votes

Opinion Polling → assertModelExists() + assertModelActive() + assertModelGlobalEligible()
   └─ poll.models[]
```

## Changes

### New Files
- `src/models/errors.ts` - Custom error hierarchy for validation failures
- `test/model-validation.test.ts` - 6 proof tests demonstrating correctness

### Modified Files
- `src/types/index.ts` - Added ModelStatus type and updated ModelInfo
- `src/models/registry.ts` - Added 6 validation methods, lifecycle states to all models
- `src/tokens/routes.ts` - Validate model IDs before token creation/update
- `src/feedback/routes.ts` - Validate feedback model IDs
- `src/knowledge/store.ts` - Validate models before recording votes
- `src/polling/stub.ts` - Validate poll model IDs
- `src/app.ts` - Wire modelRegistry through dependency injection
- `README.md` - Document model validation for users and operators
- 5 test files - Updated to pass modelRegistry and use real model IDs

## Breaking Changes
- `InMemoryKnowledgeStore` and `RedisKnowledgeStore` constructors now require `modelRegistry` parameter
- All factory functions updated to accept and wire `modelRegistry`
- Invalid model IDs are now rejected with 400 errors instead of being silently accepted

## Test Results
All 252 tests across 13 test files pass successfully, including:
- 6 new proof tests for model validation
- All existing tests updated to work with validation

## Why This Matters
This is a **P0 correctness feature**, not a convenience feature. Without it:
- Invalid model IDs could corrupt the knowledge store
- Knowledge consensus could recommend non-existent models
- Routing decisions could reference models that don't exist
- No protection against typos, aliasing, or invalid configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
