### PR TITLE
Refactor knowledge store for lazy decay and incremental stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Optional:
 - `PORT` (default: 3000)
 - `REDIS_ENABLED` / `REDIS_URL` (falls back to in-memory if disabled)
 - `LOG_LEVEL` (debug, info, warn, error)
-- `KNOWLEDGE_DECAY_RATE`, `KNOWLEDGE_DECAY_INTERVAL_HOURS`, `MIN_VOTES_FOR_STRONG_CONFIDENCE`
+- `KNOWLEDGE_DECAY_LAMBDA`, `MIN_VOTES_FOR_STRONG_CONFIDENCE`
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Policy is **always enforced before optimization**. The evaluation order is:
 The knowledge store is **not a traditional cache**:
 - Accumulates model votes per intent cluster
 - Calculates agreement scores (consensus strength)
-- Applies decay to reduce influence of old data
+- Uses lazy exponential decay at read time to reduce influence of old data
 - **Never deletes entries** - only reduces their weight
 
 ### Knowledge Scope
@@ -98,11 +98,13 @@ Wayfinder supports **configurable knowledge scope** for flexibility between shar
 - Token-scoped knowledge is opt-in for enterprise use cases
 - Scopes are completely isolated—no cross-scope leakage
 - Policy enforcement always takes precedence over knowledge scope
-- Knowledge remains long-lived with decay; it is not a cache
+- Knowledge remains long-lived with lazy decay; it is not a cache
 
 **Tradeoffs:**
 - **Global**: Maximum shared learning, network effects, best consensus
 - **Token-scoped**: Isolation, compliance, custom tuning, but slower learning
+
+> ℹ️ Knowledge decay and statistics are now lazy and incremental (see [issue #6](https://github.com/jsachs1300/wayfinder/issues/6)). Effective scores are computed at read time using exponential decay, and statistics are updated on writes, so aggregate totals are approximate over time without scanning Redis keyspaces.
 
 ### Confidence Levels
 
@@ -236,7 +238,7 @@ Request → Auth → Classify Intent → Apply Policy → Check Knowledge → Se
 
 **Knowledge Store**
 - `GET /admin/knowledge/stats` - Get knowledge store statistics
-- `POST /admin/knowledge/decay` - Manually trigger decay on all knowledge entries
+- `POST /admin/knowledge/decay` - Deprecated; decay is now applied lazily on reads
 
 **Models**
 - `GET /admin/models` - List all available models
@@ -371,29 +373,7 @@ Response:
 }
 ```
 
-```http
-# Trigger decay (all scopes)
-POST /admin/knowledge/decay
-X-Admin-Api-Key: your-admin-key
-
-# Trigger decay for global scope only
-POST /admin/knowledge/decay?scope=global
-X-Admin-Api-Key: your-admin-key
-
-# Trigger decay for specific token scope
-POST /admin/knowledge/decay?scope=token&token_id=token_abc123
-X-Admin-Api-Key: your-admin-key
-```
-
-Response:
-```json
-{
-  "message": "Decay applied",
-  "entries_affected": 42,
-  "scope": "global",
-  "timestamp": "2025-12-17T10:30:00.123Z"
-}
-```
+Manual decay is deprecated. The legacy `/admin/knowledge/decay` endpoint remains for compatibility but returns a 410 status and does not mutate data because decay is applied lazily on reads. Use `/admin/knowledge/stats` to observe approximate totals instead.
 
 #### Admin: Models
 
@@ -601,8 +581,7 @@ curl -X DELETE http://localhost:3000/admin/tokens/token_abc123 \
 | `REDIS_URL` | Redis connection URL | `redis://localhost:6379` |
 | `REDIS_ENABLED` | Enable Redis storage | `false` |
 | `LOG_LEVEL` | Logging level (debug, info, warn, error) | `info` |
-| `KNOWLEDGE_DECAY_RATE` | Decay rate per cycle (0-1) | `0.05` |
-| `KNOWLEDGE_DECAY_INTERVAL_HOURS` | Hours between automatic decay cycles | `24` |
+| `KNOWLEDGE_DECAY_LAMBDA` | Exponential decay constant applied per millisecond | `0.000000001` |
 | `MIN_VOTES_FOR_STRONG_CONFIDENCE` | Minimum votes for strong confidence | `5` |
 
 ### Token Configuration Options
@@ -755,7 +734,7 @@ src/
 │   └── engine.ts      # Policy evaluation logic
 ├── knowledge/         # Knowledge store
 │   ├── index.ts       # Knowledge store exports
-│   └── store.ts       # Vote recording, consensus, decay
+│   └── store.ts       # Vote recording, consensus, lazy decay, incremental stats
 ├── models/            # Model registry
 │   ├── index.ts       # Registry exports
 │   └── registry.ts    # Model definitions and registry

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
       - REDIS_ENABLED=true
       - REDIS_URL=redis://redis:6379
       - LOG_LEVEL=debug
-      - KNOWLEDGE_DECAY_RATE=0.05
+      - KNOWLEDGE_DECAY_LAMBDA=0.000000001
       - MIN_VOTES_FOR_STRONG_CONFIDENCE=5
     volumes:
       - ./src:/app/src:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - REDIS_ENABLED=true
       - REDIS_URL=redis://redis:6379
       - LOG_LEVEL=info
-      - KNOWLEDGE_DECAY_RATE=0.05
+      - KNOWLEDGE_DECAY_LAMBDA=0.000000001
       - MIN_VOTES_FOR_STRONG_CONFIDENCE=5
     depends_on:
       redis:

--- a/src/app.ts
+++ b/src/app.ts
@@ -140,37 +140,13 @@ export function createApp(deps?: Partial<AppDependencies>): {
     }
   });
 
-  // Trigger knowledge decay (admin only)
-  // Optional query params: ?scope=global|token&token_id=xxx
-  adminRouter.post('/knowledge/decay', async (req: Request, res: Response) => {
-    try {
-      const scope = req.query.scope as string | undefined;
-      const tokenId = req.query.token_id as string | undefined;
-
-      let scopeContext: any = undefined;
-      if (scope) {
-        scopeContext = {
-          scope,
-          token_id: scope === 'token' ? tokenId : undefined,
-        };
-      }
-
-      const decayedCount = await knowledgeStore.applyDecay(scopeContext);
-      res.json({
-        message: 'Decay applied',
-        entries_affected: decayedCount,
-        scope: scope ?? 'all',
-        timestamp: new Date().toISOString(),
-      });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      res.status(500).json({
-        error: 'InternalError',
-        message: 'Failed to apply decay',
-        details: { error: errorMessage },
-        timestamp: new Date().toISOString(),
-      });
-    }
+  // Manual decay endpoint removed in favor of lazy, read-time decay. Kept for backward compatibility.
+  adminRouter.post('/knowledge/decay', async (_req: Request, res: Response) => {
+    res.status(410).json({
+      error: 'Deprecated',
+      message: 'Decay is applied lazily at read time; manual decay is no longer available.',
+      timestamp: new Date().toISOString(),
+    });
   });
 
   // Models endpoint (admin only)

--- a/src/knowledge/store.ts
+++ b/src/knowledge/store.ts
@@ -10,29 +10,40 @@ import Redis from 'ioredis';
 import { createLogger } from '../logging';
 
 const KNOWLEDGE_PREFIX = 'wayfinder:knowledge:';
+const KNOWLEDGE_STATS_PREFIX = 'wayfinder:knowledge:stats:';
+const KNOWLEDGE_INDEX_PREFIX = 'wayfinder:knowledge:index:';
+const KNOWN_SCOPES_KEY = 'wayfinder:knowledge:scopes';
 const MIN_VOTES_FOR_STRONG = parseInt(process.env.MIN_VOTES_FOR_STRONG_CONFIDENCE ?? '5', 10);
-const DECAY_RATE = parseFloat(process.env.KNOWLEDGE_DECAY_RATE ?? '0.05');
+const DECAY_LAMBDA = parseFloat(process.env.KNOWLEDGE_DECAY_LAMBDA ?? '0.000000001');
 
 const logger = createLogger(process.env.LOG_LEVEL);
 
-/**
- * Knowledge store interface - scope-aware
- */
-export interface KnowledgeStore {
-  get(intentCluster: string, scopeContext: KnowledgeScopeContext): Promise<KnowledgeEntry | null>;
-  recordVote(
-    intentCluster: string,
-    model: string,
-    scopeContext: KnowledgeScopeContext
-  ): Promise<KnowledgeEntry>;
-  applyDecay(scopeContext?: KnowledgeScopeContext): Promise<number>;
-  getStats(scopeContext?: KnowledgeScopeContext): Promise<KnowledgeStoreStats>;
-  getConsensusModel(
-    intentCluster: string,
-    scopeContext: KnowledgeScopeContext
-  ): Promise<string | null>;
-  clear(): Promise<void>;
+interface StoredKnowledgeEntry {
+  intent_cluster: string;
+  model_votes: Record<string, number>;
+  rawScore: number;
+  lastUpdatedMs: number;
 }
+
+interface StoredStats {
+  totalCount: number;
+  totalRawScore: number;
+  totalAgreementScore: number;
+  strongCount: number;
+  moderateCount: number;
+  lowCount: number;
+  lastUpdatedMs: number | null;
+}
+
+const DEFAULT_STATS: StoredStats = {
+  totalCount: 0,
+  totalRawScore: 0,
+  totalAgreementScore: 0,
+  strongCount: 0,
+  moderateCount: 0,
+  lowCount: 0,
+  lastUpdatedMs: null,
+};
 
 /**
  * Calculate agreement score: max_votes / total_votes
@@ -51,59 +62,33 @@ function calculateAgreementScore(modelVotes: Record<string, number>): number {
 /**
  * Calculate confidence level based on agreement score and vote count
  */
-function calculateConfidenceLevel(
-  agreementScore: number,
-  totalVotes: number
-): ConfidenceLevel {
-  // Strong: agreement >= 0.8 AND enough votes
+function calculateConfidenceLevel(agreementScore: number, totalVotes: number): ConfidenceLevel {
+  if (totalVotes < 2) {
+    return 'low';
+  }
   if (agreementScore >= 0.8 && totalVotes >= MIN_VOTES_FOR_STRONG) {
     return 'strong';
   }
-  // Moderate: agreement >= 0.6
   if (agreementScore >= 0.6) {
     return 'moderate';
   }
-  // Low: otherwise
   return 'low';
 }
 
-/**
- * Apply decay to vote counts without deleting entries
- */
-function applyDecayToEntry(entry: KnowledgeEntry, decayRate: number): KnowledgeEntry {
-  const newModelVotes: Record<string, number> = {};
-  let totalVotes = 0;
-
-  for (const [model, votes] of Object.entries(entry.model_votes)) {
-    // Apply exponential decay
-    const decayedVotes = votes * (1 - decayRate);
-    // Keep votes even if very small (never delete)
-    newModelVotes[model] = Math.max(decayedVotes, 0.001);
-    totalVotes += newModelVotes[model];
-  }
-
-  const agreementScore = calculateAgreementScore(newModelVotes);
-  const confidenceLevel = calculateConfidenceLevel(agreementScore, totalVotes);
-  const newDecayFactor = entry.decay_factor * (1 - decayRate);
-
-  return {
-    ...entry,
-    model_votes: newModelVotes,
-    agreement_score: agreementScore,
-    confidence_level: confidenceLevel,
-    total_votes: totalVotes,
-    decay_factor: Math.max(newDecayFactor, 0.01), // Never decay to zero
-  };
+function computeDecayFactor(lastUpdatedMs: number, nowMs: number): number {
+  const elapsed = nowMs - lastUpdatedMs;
+  if (elapsed <= 0) return 1;
+  return Math.exp(-DECAY_LAMBDA * elapsed);
 }
 
-/**
- * Build scoped key for knowledge storage
- * Examples:
- *   global: wayfinder:knowledge:global:coding
- *   token: wayfinder:knowledge:token:token_abc123:coding
- *   org: wayfinder:knowledge:org:org_xyz789:coding (future)
- *   hybrid: not stored directly, composed at read time (future)
- */
+function applyDecayToVotes(modelVotes: Record<string, number>, factor: number): Record<string, number> {
+  const decayed: Record<string, number> = {};
+  for (const [model, votes] of Object.entries(modelVotes)) {
+    decayed[model] = Math.max(votes * factor, Number.EPSILON);
+  }
+  return decayed;
+}
+
 function buildScopedKey(intentCluster: string, scopeContext: KnowledgeScopeContext): string {
   validateScopeContext(scopeContext);
 
@@ -116,19 +101,34 @@ function buildScopedKey(intentCluster: string, scopeContext: KnowledgeScopeConte
       }
       return `${KNOWLEDGE_PREFIX}token:${scopeContext.token_id}:${intentCluster}`;
     case 'org':
-      // Future: org-level scoped knowledge
       throw new Error('Org-scoped knowledge is not yet implemented');
     case 'hybrid':
-      // Future: hybrid scope will merge global + scoped at read time
       throw new Error('Hybrid knowledge scope is not yet implemented');
     default:
       throw new Error(`Unknown knowledge scope: ${scopeContext.scope}`);
   }
 }
 
-/**
- * Validate scope context has required fields
- */
+function buildScopeKey(scopeContext: KnowledgeScopeContext): string {
+  validateScopeContext(scopeContext);
+
+  switch (scopeContext.scope) {
+    case 'global':
+      return 'global';
+    case 'token':
+      if (!scopeContext.token_id) {
+        throw new Error('token_id is required for token scope');
+      }
+      return `token:${scopeContext.token_id}`;
+    case 'org':
+      throw new Error('Org-scoped knowledge is not yet implemented');
+    case 'hybrid':
+      throw new Error('Hybrid knowledge scope is not yet implemented');
+    default:
+      throw new Error(`Unknown knowledge scope: ${scopeContext.scope}`);
+  }
+}
+
 function validateScopeContext(scopeContext: KnowledgeScopeContext): void {
   if (!scopeContext.scope) {
     throw new Error('Scope is required in KnowledgeScopeContext');
@@ -143,181 +143,194 @@ function validateScopeContext(scopeContext: KnowledgeScopeContext): void {
   }
 }
 
-/**
- * Build key pattern for scope-aware queries
- * Used for applyDecay and getStats when filtering by scope
- */
-function buildScopePattern(scopeContext?: KnowledgeScopeContext): string {
-  if (!scopeContext) {
-    // No scope context = all scopes
-    return `${KNOWLEDGE_PREFIX}*`;
-  }
+function materializeEntry(entry: StoredKnowledgeEntry, nowMs: number): KnowledgeEntry {
+  const factor = Math.max(computeDecayFactor(entry.lastUpdatedMs, nowMs), Number.EPSILON);
+  const modelVotes = applyDecayToVotes(entry.model_votes, factor);
+  const totalVotes = Object.values(modelVotes).reduce((sum, v) => sum + v, 0);
+  const agreementScore = calculateAgreementScore(modelVotes);
+  const confidenceLevel = calculateConfidenceLevel(agreementScore, totalVotes);
 
-  validateScopeContext(scopeContext);
-
-  switch (scopeContext.scope) {
-    case 'global':
-      return `${KNOWLEDGE_PREFIX}global:*`;
-    case 'token':
-      if (!scopeContext.token_id) {
-        throw new Error('token_id is required for token scope');
-      }
-      return `${KNOWLEDGE_PREFIX}token:${scopeContext.token_id}:*`;
-    case 'org':
-      throw new Error('Org-scoped knowledge is not yet implemented');
-    case 'hybrid':
-      throw new Error('Hybrid knowledge scope is not yet implemented');
-    default:
-      throw new Error(`Unknown knowledge scope: ${scopeContext.scope}`);
-  }
+  return {
+    intent_cluster: entry.intent_cluster,
+    model_votes: modelVotes,
+    agreement_score: agreementScore,
+    confidence_level: confidenceLevel,
+    total_votes: totalVotes,
+    last_updated: new Date(entry.lastUpdatedMs).toISOString(),
+    decay_factor: factor,
+    rawScore: entry.rawScore,
+    lastUpdatedMs: entry.lastUpdatedMs,
+  };
 }
 
-/**
- * In-memory knowledge store for development and fallback
- * Scope-aware: keys are now scoped (e.g., "global:coding" or "token:token_abc:coding")
- */
+function adjustConfidenceCounts(
+  stats: StoredStats,
+  previous: ConfidenceLevel | null,
+  next: ConfidenceLevel
+): void {
+  if (!previous) {
+    stats[`${next}Count` as const]++;
+    return;
+  }
+  if (previous === next) return;
+  stats[`${previous}Count` as const]--;
+  stats[`${next}Count` as const]++;
+}
+
+function aggregateStats(collection: StoredStats[], nowMs: number): KnowledgeStoreStats {
+  const totals = collection.reduce(
+    (acc, current) => {
+      acc.total_entries += current.totalCount;
+      acc.total_raw_score += current.totalRawScore;
+      acc.total_agreement_score += current.totalAgreementScore;
+      acc.entries_by_confidence.strong += current.strongCount;
+      acc.entries_by_confidence.moderate += current.moderateCount;
+      acc.entries_by_confidence.low += current.lowCount;
+      if (current.lastUpdatedMs !== null) {
+        acc.last_updated_ms =
+          acc.last_updated_ms === null
+            ? current.lastUpdatedMs
+            : Math.max(acc.last_updated_ms, current.lastUpdatedMs);
+      }
+      return acc;
+    },
+    {
+      total_entries: 0,
+      total_raw_score: 0,
+      total_agreement_score: 0,
+      entries_by_confidence: { strong: 0, moderate: 0, low: 0 },
+      last_updated_ms: null as number | null,
+    }
+  );
+
+  const approximate_effective_score = totals.total_raw_score *
+    (totals.last_updated_ms ? computeDecayFactor(totals.last_updated_ms, nowMs) : 0);
+  const average_agreement_score =
+    totals.total_entries > 0 ? totals.total_agreement_score / totals.total_entries : 0;
+
+  return {
+    total_entries: totals.total_entries,
+    total_raw_score: totals.total_raw_score,
+    approximate_effective_score,
+    entries_by_confidence: totals.entries_by_confidence,
+    average_agreement_score,
+    last_updated_ms: totals.last_updated_ms,
+  };
+}
+
+function guardRedisKeys(redis: Redis): void {
+  const originalKeys = redis.keys.bind(redis);
+  redis.keys = ((pattern: string) => {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('Redis KEYS is disabled in production code paths');
+    }
+    logger.warn('Redis KEYS called; avoid in production paths', { pattern });
+    return originalKeys(pattern);
+  }) as unknown as typeof redis.keys;
+}
+
+export interface KnowledgeStore {
+  get(intentCluster: string, scopeContext: KnowledgeScopeContext): Promise<KnowledgeEntry | null>;
+  recordVote(intentCluster: string, model: string, scopeContext: KnowledgeScopeContext): Promise<KnowledgeEntry>;
+  applyDecay(scopeContext?: KnowledgeScopeContext): Promise<number>;
+  getStats(scopeContext?: KnowledgeScopeContext): Promise<KnowledgeStoreStats>;
+  getConsensusModel(intentCluster: string, scopeContext: KnowledgeScopeContext): Promise<string | null>;
+  clear(scopeContext?: KnowledgeScopeContext): Promise<void>;
+}
+
 export class InMemoryKnowledgeStore implements KnowledgeStore {
-  private entries: Map<string, KnowledgeEntry> = new Map();
+  private entries: Map<string, StoredKnowledgeEntry> = new Map();
+  private stats: Map<string, StoredStats> = new Map();
+  private index: Map<string, Set<string>> = new Map();
   private modelRegistry: ModelRegistry;
 
   constructor(modelRegistry: ModelRegistry) {
     this.modelRegistry = modelRegistry;
   }
 
-  async get(
-    intentCluster: string,
-    scopeContext: KnowledgeScopeContext
-  ): Promise<KnowledgeEntry | null> {
+  async get(intentCluster: string, scopeContext: KnowledgeScopeContext): Promise<KnowledgeEntry | null> {
     const key = buildScopedKey(intentCluster, scopeContext);
     this.logScopeAccess('get', scopeContext, intentCluster);
-    return this.entries.get(key) ?? null;
+
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    return materializeEntry(entry, Date.now());
   }
 
-  async recordVote(
-    intentCluster: string,
-    model: string,
-    scopeContext: KnowledgeScopeContext
-  ): Promise<KnowledgeEntry> {
-    // Validate model before recording vote
+  async recordVote(intentCluster: string, model: string, scopeContext: KnowledgeScopeContext): Promise<KnowledgeEntry> {
     this.modelRegistry.assertModelExists(model, 'knowledge_vote');
     this.modelRegistry.assertModelActive(model, 'knowledge_vote');
 
-    // For global scope, ensure model is global-eligible
     if (scopeContext.scope === 'global') {
       this.modelRegistry.assertModelGlobalEligible(model, 'knowledge_vote');
     }
 
     const key = buildScopedKey(intentCluster, scopeContext);
+    const scopeKey = buildScopeKey(scopeContext);
     this.logScopeAccess('recordVote', scopeContext, intentCluster);
 
+    const nowMs = Date.now();
     const existing = this.entries.get(key);
-    const now = new Date().toISOString();
+    const decayFactor = existing ? computeDecayFactor(existing.lastUpdatedMs, nowMs) : 1;
+    const decayedVotes = existing ? applyDecayToVotes(existing.model_votes, decayFactor) : {};
 
-    if (!existing) {
-      // Create new entry
-      const entry: KnowledgeEntry = {
-        intent_cluster: intentCluster,
-        model_votes: { [model]: 1 },
-        agreement_score: 1,
-        confidence_level: 'low', // New entries start with low confidence
-        total_votes: 1,
-        last_updated: now,
-        decay_factor: 1,
-      };
-      this.entries.set(key, entry);
-      return entry;
-    }
+    const updatedVotes: Record<string, number> = { ...decayedVotes };
+    updatedVotes[model] = (updatedVotes[model] ?? 0) + 1;
+    const updatedRawScore = Object.values(updatedVotes).reduce((sum, v) => sum + v, 0);
 
-    // Update existing entry
-    const newVotes = { ...existing.model_votes };
-    newVotes[model] = (newVotes[model] ?? 0) + 1;
-    const totalVotes = Object.values(newVotes).reduce((sum, v) => sum + v, 0);
-    const agreementScore = calculateAgreementScore(newVotes);
-    const confidenceLevel = calculateConfidenceLevel(agreementScore, totalVotes);
-
-    const updated: KnowledgeEntry = {
-      ...existing,
-      model_votes: newVotes,
-      agreement_score: agreementScore,
-      confidence_level: confidenceLevel,
-      total_votes: totalVotes,
-      last_updated: now,
+    const stored: StoredKnowledgeEntry = {
+      intent_cluster: intentCluster,
+      model_votes: updatedVotes,
+      rawScore: updatedRawScore,
+      lastUpdatedMs: nowMs,
     };
 
-    this.entries.set(key, updated);
-    return updated;
+    this.entries.set(key, stored);
+    this.index.set(scopeKey, this.index.get(scopeKey) ?? new Set());
+    this.index.get(scopeKey)!.add(key);
+
+    const nextMaterialized = materializeEntry(stored, nowMs);
+    const entryForStats = existing ? nextMaterialized : { ...nextMaterialized, confidence_level: 'low' as ConfidenceLevel };
+
+    this.updateStats(scopeKey, existing ? materializeEntry(existing, nowMs) : null, entryForStats);
+    return entryForStats;
   }
 
-  async applyDecay(scopeContext?: KnowledgeScopeContext): Promise<number> {
-    let decayedCount = 0;
-    const pattern = scopeContext ? buildScopePattern(scopeContext) : null;
-
-    for (const [key, entry] of this.entries) {
-      // If scope context provided, only decay matching keys
-      if (pattern && !this.matchesPattern(key, pattern)) {
-        continue;
-      }
-
-      const decayed = applyDecayToEntry(entry, DECAY_RATE);
-      this.entries.set(key, decayed);
-      decayedCount++;
-    }
-
-    return decayedCount;
+  async applyDecay(): Promise<number> {
+    throw new Error('applyDecay is deprecated. Decay is applied lazily at read-time.');
   }
 
   async getStats(scopeContext?: KnowledgeScopeContext): Promise<KnowledgeStoreStats> {
-    const pattern = scopeContext ? buildScopePattern(scopeContext) : null;
-    const entriesByConfidence: Record<ConfidenceLevel, number> = {
-      strong: 0,
-      moderate: 0,
-      low: 0,
-    };
-    const entriesByScope: Record<KnowledgeScope, number> = {
-      global: 0,
-      token: 0,
-      org: 0,
-      hybrid: 0,
-    };
+    const nowMs = Date.now();
+    if (scopeContext) {
+      const stats = this.stats.get(buildScopeKey(scopeContext)) ?? { ...DEFAULT_STATS };
+      const aggregated = aggregateStats([stats], nowMs);
+      const entriesByScope: Record<KnowledgeScope, number> = { global: 0, token: 0, org: 0, hybrid: 0 };
+      entriesByScope[scopeContext.scope] = aggregated.total_entries;
+      return { ...aggregated, entries_by_scope: entriesByScope };
+    }
 
-    let totalAgreement = 0;
-    let entryCount = 0;
+    const allStats = Array.from(this.stats.values());
+    const aggregated = aggregateStats(allStats, nowMs);
 
-    for (const [key, entry] of this.entries) {
-      // If scope context provided, only include matching keys
-      if (pattern && !this.matchesPattern(key, pattern)) {
-        continue;
-      }
-
-      entriesByConfidence[entry.confidence_level]++;
-      totalAgreement += entry.agreement_score;
-      entryCount++;
-
-      // Track scope distribution
-      const scope = this.extractScopeFromKey(key);
-      if (scope) {
-        entriesByScope[scope]++;
-      }
+    const entriesByScope: Record<KnowledgeScope, number> = { global: 0, token: 0, org: 0, hybrid: 0 };
+    for (const [scopeKey, stats] of this.stats.entries()) {
+      const scopeType = scopeKey.startsWith('token:') ? 'token' : 'global';
+      entriesByScope[scopeType] += stats.totalCount;
     }
 
     return {
-      total_entries: entryCount,
-      entries_by_confidence: entriesByConfidence,
-      average_agreement_score: entryCount > 0 ? totalAgreement / entryCount : 0,
+      ...aggregated,
       entries_by_scope: entriesByScope,
     };
   }
 
-  async getConsensusModel(
-    intentCluster: string,
-    scopeContext: KnowledgeScopeContext
-  ): Promise<string | null> {
+  async getConsensusModel(intentCluster: string, scopeContext: KnowledgeScopeContext): Promise<string | null> {
     const entry = await this.get(intentCluster, scopeContext);
     if (!entry || entry.confidence_level === 'low') {
       return null;
     }
 
-    // Find the model with the most votes
     let maxVotes = 0;
     let consensusModel: string | null = null;
 
@@ -331,49 +344,40 @@ export class InMemoryKnowledgeStore implements KnowledgeStore {
     return consensusModel;
   }
 
-  async clear(): Promise<void> {
-    this.entries.clear();
-  }
-
-  /**
-   * Simple pattern matching for in-memory keys
-   * Converts Redis-style pattern to regex
-   */
-  private matchesPattern(key: string, pattern: string): boolean {
-    // Convert glob pattern to regex (simple version for * wildcard)
-    const regexPattern = pattern.replace(/\*/g, '.*');
-    const regex = new RegExp(`^${regexPattern}$`);
-    return regex.test(key);
-  }
-
-  /**
-   * Extract scope type from key for stats tracking
-   */
-  private extractScopeFromKey(key: string): KnowledgeScope | null {
-    // Key format: wayfinder:knowledge:{scope}:...
-    const parts = key.split(':');
-    if (parts.length >= 3) {
-      const scopePart = parts[2];
-      if (
-        scopePart === 'global' ||
-        scopePart === 'token' ||
-        scopePart === 'org' ||
-        scopePart === 'hybrid'
-      ) {
-        return scopePart;
+  async clear(scopeContext?: KnowledgeScopeContext): Promise<void> {
+    if (scopeContext) {
+      const scopeKey = buildScopeKey(scopeContext);
+      const keys = Array.from(this.index.get(scopeKey) ?? []);
+      for (const key of keys) {
+        this.entries.delete(key);
       }
+      this.index.delete(scopeKey);
+      this.stats.delete(scopeKey);
+      return;
     }
-    return null;
+
+    this.entries.clear();
+    this.index.clear();
+    this.stats.clear();
   }
 
-  /**
-   * Log non-global scope access for observability
-   */
-  private logScopeAccess(
-    operation: string,
-    scopeContext: KnowledgeScopeContext,
-    intentCluster: string
-  ): void {
+  private updateStats(scopeKey: string, previous: KnowledgeEntry | null, next: KnowledgeEntry): void {
+    const stats = this.stats.get(scopeKey) ?? { ...DEFAULT_STATS };
+    const prevRaw = previous?.rawScore ?? 0;
+    const prevAgreement = previous?.agreement_score ?? 0;
+
+    if (!previous) {
+      stats.totalCount += 1;
+    }
+
+    stats.totalRawScore += next.rawScore - prevRaw;
+    stats.totalAgreementScore += next.agreement_score - prevAgreement;
+    adjustConfidenceCounts(stats, previous ? previous.confidence_level : null, next.confidence_level);
+    stats.lastUpdatedMs = next.lastUpdatedMs;
+    this.stats.set(scopeKey, stats);
+  }
+
+  private logScopeAccess(operation: string, scopeContext: KnowledgeScopeContext, intentCluster: string): void {
     if (scopeContext.scope !== 'global') {
       logger.info(`Knowledge ${operation} using non-global scope`, {
         scope: scopeContext.scope,
@@ -385,148 +389,104 @@ export class InMemoryKnowledgeStore implements KnowledgeStore {
   }
 }
 
-/**
- * Redis-backed knowledge store for production
- * Scope-aware: uses scoped keys to isolate knowledge by scope
- */
 export class RedisKnowledgeStore implements KnowledgeStore {
   private redis: Redis;
   private modelRegistry: ModelRegistry;
 
   constructor(redis: Redis, modelRegistry: ModelRegistry) {
+    guardRedisKeys(redis);
     this.redis = redis;
     this.modelRegistry = modelRegistry;
   }
 
-  async get(
-    intentCluster: string,
-    scopeContext: KnowledgeScopeContext
-  ): Promise<KnowledgeEntry | null> {
+  async get(intentCluster: string, scopeContext: KnowledgeScopeContext): Promise<KnowledgeEntry | null> {
     const key = buildScopedKey(intentCluster, scopeContext);
     this.logScopeAccess('get', scopeContext, intentCluster);
 
-    const data = await this.redis.get(key);
-    if (!data) return null;
-    return JSON.parse(data) as KnowledgeEntry;
+    const stored = await this.redis.get(key);
+    if (!stored) return null;
+    return materializeEntry(JSON.parse(stored) as StoredKnowledgeEntry, Date.now());
   }
 
-  async recordVote(
-    intentCluster: string,
-    model: string,
-    scopeContext: KnowledgeScopeContext
-  ): Promise<KnowledgeEntry> {
-    // Validate model before recording vote
+  async recordVote(intentCluster: string, model: string, scopeContext: KnowledgeScopeContext): Promise<KnowledgeEntry> {
     this.modelRegistry.assertModelExists(model, 'knowledge_vote');
     this.modelRegistry.assertModelActive(model, 'knowledge_vote');
 
-    // For global scope, ensure model is global-eligible
     if (scopeContext.scope === 'global') {
       this.modelRegistry.assertModelGlobalEligible(model, 'knowledge_vote');
     }
 
     const key = buildScopedKey(intentCluster, scopeContext);
+    const scopeKey = buildScopeKey(scopeContext);
     this.logScopeAccess('recordVote', scopeContext, intentCluster);
 
-    const existing = await this.get(intentCluster, scopeContext);
-    const now = new Date().toISOString();
+    const nowMs = Date.now();
+    const existingRaw = await this.getStoredEntry(key);
+    const previousMaterialized = existingRaw ? materializeEntry(existingRaw, nowMs) : null;
+    const decayFactor = existingRaw ? computeDecayFactor(existingRaw.lastUpdatedMs, nowMs) : 1;
+    const decayedVotes = existingRaw ? applyDecayToVotes(existingRaw.model_votes, decayFactor) : {};
 
-    if (!existing) {
-      const entry: KnowledgeEntry = {
-        intent_cluster: intentCluster,
-        model_votes: { [model]: 1 },
-        agreement_score: 1,
-        confidence_level: 'low',
-        total_votes: 1,
-        last_updated: now,
-        decay_factor: 1,
-      };
-      await this.redis.set(key, JSON.stringify(entry));
-      return entry;
-    }
+    const updatedVotes: Record<string, number> = { ...decayedVotes };
+    updatedVotes[model] = (updatedVotes[model] ?? 0) + 1;
+    const updatedRawScore = Object.values(updatedVotes).reduce((sum, v) => sum + v, 0);
 
-    const newVotes = { ...existing.model_votes };
-    newVotes[model] = (newVotes[model] ?? 0) + 1;
-    const totalVotes = Object.values(newVotes).reduce((sum, v) => sum + v, 0);
-    const agreementScore = calculateAgreementScore(newVotes);
-    const confidenceLevel = calculateConfidenceLevel(agreementScore, totalVotes);
-
-    const updated: KnowledgeEntry = {
-      ...existing,
-      model_votes: newVotes,
-      agreement_score: agreementScore,
-      confidence_level: confidenceLevel,
-      total_votes: totalVotes,
-      last_updated: now,
+    const stored: StoredKnowledgeEntry = {
+      intent_cluster: intentCluster,
+      model_votes: updatedVotes,
+      rawScore: updatedRawScore,
+      lastUpdatedMs: nowMs,
     };
 
-    await this.redis.set(key, JSON.stringify(updated));
-    return updated;
+    const nextMaterialized = materializeEntry(stored, nowMs);
+    const entryForStats = previousMaterialized
+      ? nextMaterialized
+      : { ...nextMaterialized, confidence_level: 'low' as ConfidenceLevel };
+    await this.persistEntry(key, scopeKey, stored, previousMaterialized, entryForStats);
+    return entryForStats;
   }
 
-  async applyDecay(scopeContext?: KnowledgeScopeContext): Promise<number> {
-    const pattern = buildScopePattern(scopeContext);
-    const keys = await this.redis.keys(pattern);
-    let decayedCount = 0;
-
-    for (const key of keys) {
-      const data = await this.redis.get(key);
-      if (data) {
-        const entry = JSON.parse(data) as KnowledgeEntry;
-        const decayed = applyDecayToEntry(entry, DECAY_RATE);
-        await this.redis.set(key, JSON.stringify(decayed));
-        decayedCount++;
-      }
-    }
-
-    return decayedCount;
+  async applyDecay(): Promise<number> {
+    throw new Error('applyDecay is deprecated. Decay is applied lazily at read-time.');
   }
 
   async getStats(scopeContext?: KnowledgeScopeContext): Promise<KnowledgeStoreStats> {
-    const pattern = buildScopePattern(scopeContext);
-    const keys = await this.redis.keys(pattern);
-    const entriesByConfidence: Record<ConfidenceLevel, number> = {
-      strong: 0,
-      moderate: 0,
-      low: 0,
-    };
-    const entriesByScope: Record<KnowledgeScope, number> = {
-      global: 0,
-      token: 0,
-      org: 0,
-      hybrid: 0,
-    };
-
-    let totalAgreement = 0;
-    let entryCount = 0;
-
-    for (const key of keys) {
-      const data = await this.redis.get(key);
-      if (data) {
-        const entry = JSON.parse(data) as KnowledgeEntry;
-        entriesByConfidence[entry.confidence_level]++;
-        totalAgreement += entry.agreement_score;
-        entryCount++;
-
-        // Track scope distribution
-        const scope = this.extractScopeFromKey(key);
-        if (scope) {
-          entriesByScope[scope]++;
-        }
-      }
+    const nowMs = Date.now();
+    if (scopeContext) {
+      const stats = await this.readStats(buildScopeKey(scopeContext));
+      const aggregated = aggregateStats([stats], nowMs);
+      const entriesByScope: Record<KnowledgeScope, number> = { global: 0, token: 0, org: 0, hybrid: 0 };
+      entriesByScope[scopeContext.scope] = aggregated.total_entries;
+      return { ...aggregated, entries_by_scope: entriesByScope };
     }
 
-    return {
-      total_entries: entryCount,
-      entries_by_confidence: entriesByConfidence,
-      average_agreement_score: entryCount > 0 ? totalAgreement / entryCount : 0,
-      entries_by_scope: entriesByScope,
-    };
+    const scopeKeys = await this.redis.smembers(KNOWN_SCOPES_KEY);
+    if (scopeKeys.length === 0) {
+      return aggregateStats([], nowMs);
+    }
+
+    const statsList = await this.redis
+      .multi(scopeKeys.map(scopeKey => ['hgetall', `${KNOWLEDGE_STATS_PREFIX}${scopeKey}`] as const))
+      .exec();
+
+    const parsedStats: StoredStats[] = [];
+    statsList?.forEach(result => {
+      const [, data] = result ?? [];
+      parsedStats.push(this.parseStatsHash((data as Record<string, string>) ?? {}));
+    });
+
+    const aggregated = aggregateStats(parsedStats, nowMs);
+    const entriesByScope: Record<KnowledgeScope, number> = { global: 0, token: 0, org: 0, hybrid: 0 };
+
+    scopeKeys.forEach((scopeKey, index) => {
+      const stats = parsedStats[index];
+      const scopeType: KnowledgeScope = scopeKey.startsWith('token:') ? 'token' : 'global';
+      entriesByScope[scopeType] += stats.totalCount;
+    });
+
+    return { ...aggregated, entries_by_scope: entriesByScope };
   }
 
-  async getConsensusModel(
-    intentCluster: string,
-    scopeContext: KnowledgeScopeContext
-  ): Promise<string | null> {
+  async getConsensusModel(intentCluster: string, scopeContext: KnowledgeScopeContext): Promise<string | null> {
     const entry = await this.get(intentCluster, scopeContext);
     if (!entry || entry.confidence_level === 'low') {
       return null;
@@ -545,41 +505,103 @@ export class RedisKnowledgeStore implements KnowledgeStore {
     return consensusModel;
   }
 
-  async clear(): Promise<void> {
-    const keys = await this.redis.keys(KNOWLEDGE_PREFIX + '*');
-    if (keys.length > 0) {
-      await this.redis.del(...keys);
+  async clear(scopeContext?: KnowledgeScopeContext): Promise<void> {
+    if (scopeContext) {
+      await this.clearScope(buildScopeKey(scopeContext));
+      return;
     }
+
+    const scopeKeys = await this.redis.smembers(KNOWN_SCOPES_KEY);
+    for (const scopeKey of scopeKeys) {
+      await this.clearScope(scopeKey);
+    }
+    await this.redis.del(KNOWN_SCOPES_KEY);
   }
 
-  /**
-   * Extract scope type from key for stats tracking
-   */
-  private extractScopeFromKey(key: string): KnowledgeScope | null {
-    // Key format: wayfinder:knowledge:{scope}:...
-    const parts = key.split(':');
-    if (parts.length >= 3) {
-      const scopePart = parts[2];
-      if (
-        scopePart === 'global' ||
-        scopePart === 'token' ||
-        scopePart === 'org' ||
-        scopePart === 'hybrid'
-      ) {
-        return scopePart;
-      }
+  private async clearScope(scopeKey: string): Promise<void> {
+    const indexKey = `${KNOWLEDGE_INDEX_PREFIX}${scopeKey}`;
+    while (true) {
+      const batch = await this.redis.zrange(indexKey, 0, 99);
+      if (batch.length === 0) break;
+      const pipeline = this.redis.multi();
+      pipeline.unlink(...batch);
+      pipeline.zrem(indexKey, ...batch);
+      await pipeline.exec();
     }
-    return null;
+    await this.redis.del(indexKey, `${KNOWLEDGE_STATS_PREFIX}${scopeKey}`);
+    await this.redis.srem(KNOWN_SCOPES_KEY, scopeKey);
   }
 
-  /**
-   * Log non-global scope access for observability
-   */
-  private logScopeAccess(
-    operation: string,
-    scopeContext: KnowledgeScopeContext,
-    intentCluster: string
-  ): void {
+  private async getStoredEntry(key: string): Promise<StoredKnowledgeEntry | null> {
+    const data = await this.redis.get(key);
+    if (!data) return null;
+    return JSON.parse(data) as StoredKnowledgeEntry;
+  }
+
+  private async persistEntry(
+    key: string,
+    scopeKey: string,
+    entry: StoredKnowledgeEntry,
+    previous: KnowledgeEntry | null,
+    next: KnowledgeEntry
+  ): Promise<void> {
+    const statsKey = `${KNOWLEDGE_STATS_PREFIX}${scopeKey}`;
+    const indexKey = `${KNOWLEDGE_INDEX_PREFIX}${scopeKey}`;
+    const prevRaw = previous?.rawScore ?? 0;
+    const prevAgreement = previous?.agreement_score ?? 0;
+
+    const pipeline = this.redis.multi();
+    pipeline.set(key, JSON.stringify(entry));
+    pipeline.zadd(indexKey, entry.lastUpdatedMs, key);
+    pipeline.sadd(KNOWN_SCOPES_KEY, scopeKey);
+
+    pipeline.hincrby(statsKey, 'totalCount', previous ? 0 : 1);
+    pipeline.hincrbyfloat(statsKey, 'totalRawScore', entry.rawScore - prevRaw);
+    pipeline.hincrbyfloat(statsKey, 'totalAgreementScore', next.agreement_score - prevAgreement);
+    pipeline.hset(statsKey, 'lastUpdatedMs', entry.lastUpdatedMs);
+    pipeline.hincrby(statsKey, 'strongCount', this.confidenceDelta(previous?.confidence_level, next.confidence_level, 'strong'));
+    pipeline.hincrby(statsKey, 'moderateCount', this.confidenceDelta(previous?.confidence_level, next.confidence_level, 'moderate'));
+    pipeline.hincrby(statsKey, 'lowCount', this.confidenceDelta(previous?.confidence_level, next.confidence_level, 'low'));
+
+    await pipeline.exec();
+  }
+
+  private confidenceDelta(
+    previous: ConfidenceLevel | undefined,
+    next: ConfidenceLevel,
+    target: ConfidenceLevel
+  ): number {
+    if (!previous) {
+      return next === target ? 1 : 0;
+    }
+    if (previous === next) return 0;
+    if (previous === target) return -1;
+    if (next === target) return 1;
+    return 0;
+  }
+
+  private async readStats(scopeKey: string): Promise<StoredStats> {
+    const data = await this.redis.hgetall(`${KNOWLEDGE_STATS_PREFIX}${scopeKey}`);
+    return this.parseStatsHash(data);
+  }
+
+  private parseStatsHash(data: Record<string, string>): StoredStats {
+    if (!data || Object.keys(data).length === 0) {
+      return { ...DEFAULT_STATS };
+    }
+
+    return {
+      totalCount: parseInt(data.totalCount ?? '0', 10),
+      totalRawScore: parseFloat(data.totalRawScore ?? '0'),
+      totalAgreementScore: parseFloat(data.totalAgreementScore ?? '0'),
+      strongCount: parseInt(data.strongCount ?? '0', 10),
+      moderateCount: parseInt(data.moderateCount ?? '0', 10),
+      lowCount: parseInt(data.lowCount ?? '0', 10),
+      lastUpdatedMs: data.lastUpdatedMs ? parseInt(data.lastUpdatedMs, 10) : null,
+    };
+  }
+
+  private logScopeAccess(operation: string, scopeContext: KnowledgeScopeContext, intentCluster: string): void {
     if (scopeContext.scope !== 'global') {
       logger.info(`Knowledge ${operation} using non-global scope`, {
         scope: scopeContext.scope,
@@ -591,9 +613,6 @@ export class RedisKnowledgeStore implements KnowledgeStore {
   }
 }
 
-/**
- * Create appropriate knowledge store based on environment
- */
 export function createKnowledgeStore(redis: Redis | undefined, modelRegistry: ModelRegistry): KnowledgeStore {
   if (redis) {
     return new RedisKnowledgeStore(redis, modelRegistry);

--- a/src/tokens/store.ts
+++ b/src/tokens/store.ts
@@ -5,6 +5,7 @@ import Redis from 'ioredis';
 
 const TOKEN_PREFIX = 'wayfinder:token:';
 const TOKEN_HASH_INDEX = 'wayfinder:token_hash_index:';
+const TOKEN_INDEX_KEY = 'wayfinder:token:index';
 
 /**
  * Token storage interface for flexibility
@@ -169,6 +170,7 @@ export class RedisTokenStore implements TokenStore {
 
     await this.redis.set(TOKEN_PREFIX + id, JSON.stringify(config));
     await this.redis.set(TOKEN_HASH_INDEX + tokenHash, id);
+    await this.redis.sadd(TOKEN_INDEX_KEY, id);
 
     return { id, token, config };
   }
@@ -233,22 +235,26 @@ export class RedisTokenStore implements TokenStore {
 
     await this.redis.del(TOKEN_HASH_INDEX + existing.token_hash);
     await this.redis.del(TOKEN_PREFIX + id);
+    await this.redis.srem(TOKEN_INDEX_KEY, id);
     return true;
   }
 
   async list(): Promise<TokenConfig[]> {
-    const keys = await this.redis.keys(TOKEN_PREFIX + '*');
-    if (keys.length === 0) return [];
+    const ids = await this.redis.smembers(TOKEN_INDEX_KEY);
+    if (ids.length === 0) return [];
+
+    const pipeline = this.redis.multi();
+    ids.forEach(id => pipeline.get(TOKEN_PREFIX + id));
+    const results = await pipeline.exec();
 
     const configs: TokenConfig[] = [];
-    for (const key of keys) {
-      // Skip hash index keys
-      if (key.includes('hash_index')) continue;
-      const data = await this.redis.get(key);
-      if (data) {
+    results?.forEach(result => {
+      const [, data] = result ?? [];
+      if (typeof data === 'string') {
         configs.push(JSON.parse(data) as TokenConfig);
       }
-    }
+    });
+
     return configs;
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,13 +116,18 @@ export interface KnowledgeEntry {
   total_votes: number;
   last_updated: string;
   decay_factor: number;
+  rawScore: number;
+  lastUpdatedMs: number;
 }
 
 export interface KnowledgeStoreStats {
   total_entries: number;
+  total_raw_score: number;
+  approximate_effective_score: number;
   entries_by_confidence: Record<ConfidenceLevel, number>;
   average_agreement_score: number;
   entries_by_scope?: Record<KnowledgeScope, number>; // Optional breakdown by scope
+  last_updated_ms: number | null;
 }
 
 // Scope context for knowledge operations

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -261,8 +261,8 @@ describe('API Integration Tests', () => {
         .post('/admin/knowledge/decay')
         .set('X-Admin-Api-Key', adminApiKey);
 
-      expect(response.status).toBe(200);
-      expect(response.body.entries_affected).toBe(1);
+      expect(response.status).toBe(410);
+      expect(response.body.error).toBe('Deprecated');
     });
   });
 

--- a/test/knowledge-edge-cases.test.ts
+++ b/test/knowledge-edge-cases.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { InMemoryKnowledgeStore } from '../src/knowledge/store';
 import { KnowledgeScopeContext } from '../src/types';
 import { createModelRegistry } from '../src/models';
@@ -15,6 +15,10 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
   beforeEach(async () => {
     const modelRegistry = createModelRegistry();
     store = new InMemoryKnowledgeStore(modelRegistry);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('Division by Zero and NaN Prevention', () => {
@@ -38,12 +42,11 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
   describe('Floating Point Precision', () => {
     it('should handle fractional votes after decay without precision errors', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
       await store.recordVote('test', modelA, globalScope);
 
-      // Apply many decay cycles
-      for (let i = 0; i < 50; i++) {
-        await store.applyDecay();
-      }
+      vi.setSystemTime(new Date('2024-01-01T06:00:00Z'));
 
       const entry = await store.get('test', globalScope);
 
@@ -58,13 +61,14 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should maintain agreement score between 0 and 1', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
       // Record votes with various distributions
       await store.recordVote('test1', modelA, globalScope);
       await store.recordVote('test1', modelA, globalScope);
       await store.recordVote('test1', modelB, globalScope);
 
-      await store.applyDecay();
-      await store.applyDecay();
+      vi.setSystemTime(new Date('2024-01-02T00:00:00Z'));
 
       const entry = await store.get('test1', globalScope);
 
@@ -73,19 +77,17 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should handle very small vote counts after extensive decay', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
       await store.recordVote('test', modelA, globalScope);
 
-      // Extreme decay
-      for (let i = 0; i < 200; i++) {
-        await store.applyDecay();
-      }
+      vi.setSystemTime(new Date('2024-02-01T00:00:00Z'));
 
       const entry = await store.get('test', globalScope);
 
       // Should enforce minimum values to prevent underflow
       expect(entry!.model_votes[modelA]).toBeGreaterThan(0);
-      expect(entry!.model_votes[modelA]).toBeGreaterThanOrEqual(0.001);
-      expect(entry!.decay_factor).toBeGreaterThanOrEqual(0.01);
+      expect(entry!.decay_factor).toBeGreaterThan(0);
     });
   });
 
@@ -99,8 +101,8 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
       const entry = await store.get('coding', globalScope);
       // All votes should be recorded
-      expect(entry!.total_votes).toBe(100);
-      expect(entry!.model_votes['gpt-4-turbo']).toBe(100);
+      expect(entry!.total_votes).toBeCloseTo(100, 3);
+      expect(entry!.model_votes['gpt-4-turbo']).toBeCloseTo(100, 3);
     });
 
     it('should handle concurrent votes for different models in same cluster', async () => {
@@ -112,10 +114,10 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
       await Promise.all(promises);
 
       const entry = await store.get('coding', globalScope);
-      expect(entry!.total_votes).toBe(100);
-      expect(entry!.model_votes[modelA]).toBe(60);
-      expect(entry!.model_votes[modelB]).toBe(40);
-      expect(entry!.agreement_score).toBe(0.6); // 60/100
+      expect(entry!.total_votes).toBeCloseTo(100, 3);
+      expect(entry!.model_votes[modelA]).toBeCloseTo(60, 3);
+      expect(entry!.model_votes[modelB]).toBeCloseTo(40, 3);
+      expect(entry!.agreement_score).toBeCloseTo(0.6, 3); // 60/100
     });
 
     it('should handle concurrent votes across multiple clusters', async () => {
@@ -128,25 +130,12 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
       for (const cluster of clusters) {
         const entry = await store.get(cluster, globalScope);
-        expect(entry!.total_votes).toBe(10);
+        expect(entry!.total_votes).toBeCloseTo(10, 6);
       }
     });
 
-    it('should handle concurrent decay operations', async () => {
-      // Set up initial data
-      await store.recordVote('test', modelA, globalScope);
-
-      // Run multiple decay operations concurrently
-      const promises = Array.from({ length: 5 }, () => store.applyDecay());
-      const results = await Promise.all(promises);
-
-      // All should report successful decay
-      expect(results.every(count => count >= 0)).toBe(true);
-
-      const entry = await store.get('test', globalScope);
-      // Entry should still exist
-      expect(entry).not.toBeNull();
-      expect(entry!.model_votes[modelA]).toBeGreaterThan(0);
+    it('rejects explicit decay requests now that decay is lazy', async () => {
+      await expect(store.applyDecay()).rejects.toThrow();
     });
   });
 
@@ -205,6 +194,8 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should handle transition from strong to moderate after decay', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
       // Build strong confidence
       for (let i = 0; i < 10; i++) {
         await store.recordVote('test', modelA, globalScope);
@@ -216,10 +207,8 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
       // Decay should reduce vote count below minimum for strong
       const minVotes = parseInt(process.env.MIN_VOTES_FOR_STRONG_CONFIDENCE ?? '5', 10);
 
-      while (entry!.total_votes >= minVotes) {
-        await store.applyDecay();
-        entry = (await store.get('test', globalScope))!;
-      }
+      vi.setSystemTime(new Date('2024-01-15T00:00:00Z'));
+      entry = (await store.get('test', globalScope))!;
 
       // Should now be moderate (agreement still high but not enough votes)
       expect(entry.agreement_score).toBeGreaterThanOrEqual(0.8);
@@ -276,7 +265,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
       const entry = await store.get('test', globalScope);
 
-      expect(entry!.agreement_score).toBe(0.5);
+      expect(entry!.agreement_score).toBeCloseTo(0.5, 3);
       expect(entry!.confidence_level).toBe('low');
     });
   });
@@ -304,7 +293,9 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
     });
 
     it('should handle consensus model selection after decay', async () => {
-      // Strong initial consensus
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
       for (let i = 0; i < 8; i++) {
         await store.recordVote('test', modelA, globalScope);
       }
@@ -315,7 +306,7 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
       const beforeDecay = await store.getConsensusModel('test', globalScope);
       expect(beforeDecay).toBe(modelA);
 
-      await store.applyDecay();
+      vi.setSystemTime(new Date('2024-01-02T00:00:00Z'));
 
       const afterDecay = await store.getConsensusModel('test', globalScope);
       // Proportions stay same, so consensus should remain
@@ -364,32 +355,36 @@ describe('KnowledgeStore Edge Cases and Race Conditions', () => {
 
   describe('Decay Factor Edge Cases', () => {
     it('should never decay below minimum threshold', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
       await store.recordVote('test', modelA, globalScope);
 
-      // Apply extreme decay
-      for (let i = 0; i < 1000; i++) {
-        await store.applyDecay();
-      }
+      vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
 
       const entry = await store.get('test', globalScope);
 
-      // Should enforce minimum decay_factor
-      expect(entry!.decay_factor).toBeGreaterThanOrEqual(0.01);
+      // Should remain positive even after long time
+      expect(entry!.decay_factor).toBeGreaterThan(0);
     });
 
     it('should maintain decay_factor as multiplicative', async () => {
+      vi.useFakeTimers();
+      const lambda = parseFloat(process.env.KNOWLEDGE_DECAY_LAMBDA ?? '0.000000001');
+      const start = new Date('2024-01-01T00:00:00Z').getTime();
+
+      vi.setSystemTime(start);
       await store.recordVote('test', modelA, globalScope);
 
       const initial = await store.get('test', globalScope);
-      const initialFactor = initial!.decay_factor;
 
-      await store.applyDecay();
+      const later = start + 60 * 60 * 1000; // +1 hour
+      vi.setSystemTime(later);
 
       const after = await store.get('test', globalScope);
-      const decayRate = parseFloat(process.env.KNOWLEDGE_DECAY_RATE ?? '0.05');
+      const expectedFactor = Math.exp(-lambda * (later - start));
 
-      // decay_factor should be multiplied by (1 - decay_rate)
-      expect(after!.decay_factor).toBeCloseTo(initialFactor * (1 - decayRate), 4);
+      expect(after!.decay_factor).toBeCloseTo(expectedFactor, 5);
     });
   });
 

--- a/test/knowledge-scope.test.ts
+++ b/test/knowledge-scope.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { InMemoryKnowledgeStore } from '../src/knowledge/store';
 import { KnowledgeScopeContext } from '../src/types';
 import { createModelRegistry } from '../src/models';
@@ -15,6 +15,10 @@ describe('Knowledge Scope', () => {
     knowledgeStore = new InMemoryKnowledgeStore(modelRegistry);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('Global Scope (Default)', () => {
     it('should record and retrieve votes in global scope', async () => {
       const scopeContext: KnowledgeScopeContext = { scope: 'global' };
@@ -25,9 +29,9 @@ describe('Knowledge Scope', () => {
 
       const entry = await knowledgeStore.get('coding', scopeContext);
       expect(entry).not.toBeNull();
-      expect(entry?.total_votes).toBe(3);
-      expect(entry?.model_votes['gpt-4-turbo']).toBe(2);
-      expect(entry?.model_votes['claude-3-5-sonnet']).toBe(1);
+      expect(entry?.total_votes).toBeCloseTo(3, 6);
+      expect(entry?.model_votes['gpt-4-turbo']).toBeCloseTo(2, 6);
+      expect(entry?.model_votes['claude-3-5-sonnet']).toBeCloseTo(1, 6);
     });
 
     it('should calculate consensus model in global scope', async () => {
@@ -56,8 +60,8 @@ describe('Knowledge Scope', () => {
 
       const entry = await knowledgeStore.get('coding', tokenScope);
       expect(entry).not.toBeNull();
-      expect(entry?.total_votes).toBe(2);
-      expect(entry?.model_votes['gpt-4o']).toBe(2);
+      expect(entry?.total_votes).toBeCloseTo(2, 6);
+      expect(entry?.model_votes['gpt-4o']).toBeCloseTo(2, 6);
     });
 
     it('should isolate knowledge between different tokens', async () => {
@@ -79,12 +83,12 @@ describe('Knowledge Scope', () => {
 
       // Verify token 1 knowledge
       const entry1 = await knowledgeStore.get('coding', token1Scope);
-      expect(entry1?.model_votes['gpt-4-turbo']).toBe(2);
+      expect(entry1?.model_votes['gpt-4-turbo']).toBeCloseTo(2, 6);
       expect(entry1?.model_votes['claude-3-5-sonnet']).toBeUndefined();
 
       // Verify token 2 knowledge
       const entry2 = await knowledgeStore.get('coding', token2Scope);
-      expect(entry2?.model_votes['claude-3-5-sonnet']).toBe(1);
+      expect(entry2?.model_votes['claude-3-5-sonnet']).toBeCloseTo(1, 6);
       expect(entry2?.model_votes['gpt-4-turbo']).toBeUndefined();
     });
 
@@ -189,57 +193,31 @@ describe('Knowledge Scope', () => {
   });
 
   describe('Decay by Scope', () => {
-    it('should decay all scopes when no filter provided', async () => {
+    it('rejects manual decay calls and relies on lazy decay', async () => {
+      await expect(knowledgeStore.applyDecay()).rejects.toThrow();
+    });
+
+    it('applies lazy decay independently per scope on reads', async () => {
+      vi.useFakeTimers();
       const globalScope: KnowledgeScopeContext = { scope: 'global' };
       const tokenScope: KnowledgeScopeContext = {
         scope: 'token',
         token_id: 'token_123',
       };
 
+      vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
       await knowledgeStore.recordVote('coding', 'gpt-4-turbo', globalScope);
       await knowledgeStore.recordVote('coding', 'gpt-4o', tokenScope);
 
-      const decayedCount = await knowledgeStore.applyDecay();
-      expect(decayedCount).toBe(2);
-    });
+      const immediateGlobal = await knowledgeStore.get('coding', globalScope);
+      const immediateToken = await knowledgeStore.get('coding', tokenScope);
 
-    it('should decay only global scope when filtered', async () => {
-      const globalScope: KnowledgeScopeContext = { scope: 'global' };
-      const tokenScope: KnowledgeScopeContext = {
-        scope: 'token',
-        token_id: 'token_123',
-      };
+      vi.setSystemTime(new Date('2024-01-02T00:00:00Z'));
+      const decayedGlobal = await knowledgeStore.get('coding', globalScope);
+      const decayedToken = await knowledgeStore.get('coding', tokenScope);
 
-      await knowledgeStore.recordVote('coding', 'gpt-4-turbo', globalScope);
-      await knowledgeStore.recordVote('coding', 'gpt-4o', tokenScope);
-
-      const decayedCount = await knowledgeStore.applyDecay(globalScope);
-      expect(decayedCount).toBe(1);
-
-      // Verify token knowledge was not decayed
-      const tokenEntry = await knowledgeStore.get('coding', tokenScope);
-      expect(tokenEntry?.decay_factor).toBe(1); // Not decayed
-    });
-
-    it('should decay only specific token when filtered', async () => {
-      const token1Scope: KnowledgeScopeContext = {
-        scope: 'token',
-        token_id: 'token_123',
-      };
-      const token2Scope: KnowledgeScopeContext = {
-        scope: 'token',
-        token_id: 'token_456',
-      };
-
-      await knowledgeStore.recordVote('coding', 'gpt-4-turbo', token1Scope);
-      await knowledgeStore.recordVote('coding', 'claude-3-5-sonnet', token2Scope);
-
-      const decayedCount = await knowledgeStore.applyDecay(token1Scope);
-      expect(decayedCount).toBe(1);
-
-      // Verify only token1 was decayed
-      const token2Entry = await knowledgeStore.get('coding', token2Scope);
-      expect(token2Entry?.decay_factor).toBe(1); // Not decayed
+      expect(decayedGlobal!.total_votes).toBeLessThan(immediateGlobal!.total_votes);
+      expect(decayedToken!.total_votes).toBeLessThan(immediateToken!.total_votes);
     });
   });
 

--- a/test/knowledge.test.ts
+++ b/test/knowledge.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { InMemoryKnowledgeStore } from '../src/knowledge/store';
 import { KnowledgeScopeContext } from '../src/types';
 import { createModelRegistry } from '../src/models';
@@ -17,6 +17,10 @@ describe('KnowledgeStore', () => {
     store = new InMemoryKnowledgeStore(modelRegistry);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('Agreement Score Calculation', () => {
     it('should calculate agreement_score as max_votes / total_votes', async () => {
       // Record 8 votes for model A, 2 for model B
@@ -30,7 +34,7 @@ describe('KnowledgeStore', () => {
       const entry = await store.get('coding', globalScope);
 
       expect(entry).not.toBeNull();
-      expect(entry!.agreement_score).toBe(0.8); // 8/10 = 0.8
+      expect(entry!.agreement_score).toBeCloseTo(0.8, 3); // 8/10 = 0.8
     });
 
     it('should return 1.0 agreement when only one model has votes', async () => {
@@ -49,7 +53,7 @@ describe('KnowledgeStore', () => {
 
       const entry = await store.get('coding', globalScope);
 
-      expect(entry!.agreement_score).toBe(0.5); // 1/2 = 0.5
+      expect(entry!.agreement_score).toBeCloseTo(0.5, 3); // 1/2 = 0.5
     });
   });
 
@@ -76,7 +80,7 @@ describe('KnowledgeStore', () => {
 
       const entry = await store.get('coding', globalScope);
 
-      expect(entry!.agreement_score).toBe(0.7);
+      expect(entry!.agreement_score).toBeCloseTo(0.7, 3);
       expect(entry!.confidence_level).toBe('moderate');
     });
 
@@ -112,49 +116,31 @@ describe('KnowledgeStore', () => {
   });
 
   describe('Knowledge Decay Behavior', () => {
-    it('should reduce vote counts on decay', async () => {
-      // Initial votes
+    it('applies decay lazily on read', async () => {
+      vi.useFakeTimers();
+      const start = new Date('2024-01-01T00:00:00.000Z');
+      vi.setSystemTime(start);
+
       for (let i = 0; i < 10; i++) {
         await store.recordVote('coding', modelA, globalScope);
       }
 
-      const before = await store.get('coding', globalScope);
-      expect(before!.total_votes).toBe(10);
+      const immediate = await store.get('coding', globalScope);
+      expect(immediate!.total_votes).toBe(10);
 
-      // Apply decay
-      await store.applyDecay();
+      const later = new Date(start.getTime() + 60 * 60 * 1000);
+      vi.setSystemTime(later);
 
-      const after = await store.get('coding', globalScope);
-      expect(after!.total_votes).toBeLessThan(10);
+      const decayed = await store.get('coding', globalScope);
+      expect(decayed!.total_votes).toBeLessThan(immediate!.total_votes);
+      expect(decayed!.decay_factor).toBeLessThan(1);
     });
 
-    it('should never delete entries on decay', async () => {
-      await store.recordVote('coding', modelA, globalScope);
+    it('maintains proportions when decayed at read time', async () => {
+      vi.useFakeTimers();
+      const start = new Date('2024-01-01T00:00:00.000Z');
+      vi.setSystemTime(start);
 
-      // Apply many decay cycles
-      for (let i = 0; i < 100; i++) {
-        await store.applyDecay();
-      }
-
-      const entry = await store.get('coding', globalScope);
-
-      // Entry should still exist
-      expect(entry).not.toBeNull();
-      expect(entry!.model_votes[modelA]).toBeGreaterThan(0);
-    });
-
-    it('should reduce decay_factor over time', async () => {
-      await store.recordVote('coding', modelA, globalScope);
-      const before = await store.get('coding', globalScope);
-
-      await store.applyDecay();
-
-      const after = await store.get('coding', globalScope);
-      expect(after!.decay_factor).toBeLessThan(before!.decay_factor);
-    });
-
-    it('should maintain relative vote proportions after decay', async () => {
-      // 8 votes for A, 2 for B
       for (let i = 0; i < 8; i++) {
         await store.recordVote('coding', modelA, globalScope);
       }
@@ -162,17 +148,13 @@ describe('KnowledgeStore', () => {
         await store.recordVote('coding', modelB, globalScope);
       }
 
-      const before = await store.get('coding', globalScope);
-      const ratioBefore =
-        before!.model_votes[modelA]! / before!.model_votes[modelB]!;
+      const baseline = await store.get('coding', globalScope);
+      const ratioBefore = baseline!.model_votes[modelA]! / baseline!.model_votes[modelB]!;
 
-      await store.applyDecay();
+      vi.setSystemTime(new Date(start.getTime() + 30 * 60 * 1000));
+      const decayed = await store.get('coding', globalScope);
+      const ratioAfter = decayed!.model_votes[modelA]! / decayed!.model_votes[modelB]!;
 
-      const after = await store.get('coding', globalScope);
-      const ratioAfter =
-        after!.model_votes[modelA]! / after!.model_votes[modelB]!;
-
-      // Ratio should remain approximately the same
       expect(Math.abs(ratioBefore - ratioAfter)).toBeLessThan(0.01);
     });
   });
@@ -228,9 +210,12 @@ describe('KnowledgeStore', () => {
       const stats = await store.getStats();
 
       expect(stats.total_entries).toBe(3);
+      expect(stats.total_raw_score).toBeCloseTo(21, 6);
       expect(stats.entries_by_confidence.strong).toBe(1);
       expect(stats.entries_by_confidence.moderate).toBe(1);
       expect(stats.entries_by_confidence.low).toBe(1);
+      expect(stats.average_agreement_score).toBeCloseTo(0.9);
+      expect(stats.approximate_effective_score).toBeLessThanOrEqual(stats.total_raw_score);
     });
 
     it('should calculate average agreement score', async () => {
@@ -245,7 +230,8 @@ describe('KnowledgeStore', () => {
 
       const stats = await store.getStats();
 
-      expect(stats.average_agreement_score).toBe(0.75); // (1 + 0.5) / 2
+      expect(stats.average_agreement_score).toBeCloseTo(0.75); // (1 + 0.5) / 2
+      expect(stats.total_raw_score).toBeCloseTo(7, 6);
     });
   });
 });

--- a/test/model-validation.test.ts
+++ b/test/model-validation.test.ts
@@ -143,8 +143,8 @@ describe('Model Validation - Proof Tests', () => {
 
     const initialEntry = await knowledgeStore.get('coding', { scope: 'global' });
     expect(initialEntry).toBeTruthy();
-    expect(initialEntry!.total_votes).toBe(1);
-    expect(initialEntry!.model_votes['active-model']).toBe(1);
+    expect(initialEntry!.total_votes).toBeCloseTo(1, 6);
+    expect(initialEntry!.model_votes['active-model']).toBeCloseTo(1, 6);
 
     // Attempt to record vote with invalid model should throw
     await expect(async () => {
@@ -156,8 +156,8 @@ describe('Model Validation - Proof Tests', () => {
     // Verify knowledge was NOT altered
     const finalEntry = await knowledgeStore.get('coding', { scope: 'global' });
     expect(finalEntry).toBeTruthy();
-    expect(finalEntry!.total_votes).toBe(1); // Still 1, not 2
-    expect(finalEntry!.model_votes['active-model']).toBe(1);
+    expect(finalEntry!.total_votes).toBeCloseTo(1, 6); // Still 1, not 2
+    expect(finalEntry!.model_votes['active-model']).toBeCloseTo(1, 6);
     expect(finalEntry!.model_votes['invalid-model-xyz']).toBeUndefined();
 
     // Attempt with disabled model should also not alter votes
@@ -168,7 +168,7 @@ describe('Model Validation - Proof Tests', () => {
     }).rejects.toThrow(DisabledModelError);
 
     const finalEntry2 = await knowledgeStore.get('coding', { scope: 'global' });
-    expect(finalEntry2!.total_votes).toBe(1); // Still unchanged
+    expect(finalEntry2!.total_votes).toBeCloseTo(1, 6); // Still unchanged
   });
 
   // ========== PROOF TEST 4: Polling cannot emit unknown model IDs ==========
@@ -245,7 +245,7 @@ describe('Model Validation - Proof Tests', () => {
     ).resolves.toBeTruthy();
 
     const entry = await knowledgeStore.get('coding', { scope: 'global' });
-    expect(entry!.model_votes[deprecatedModel]).toBe(1);
+    expect(entry!.model_votes[deprecatedModel]).toBeCloseTo(1, 6);
   });
 
   // ========== BONUS: Configuration contradiction detection ==========

--- a/test/routing-edge-cases.test.ts
+++ b/test/routing-edge-cases.test.ts
@@ -333,7 +333,7 @@ describe('RoutingEngine Edge Cases and Security', () => {
       }, config);
 
       expect(result.routing_decision.agreement_score).not.toBeNull();
-      expect(result.routing_decision.agreement_score).toBe(0.8);
+      expect(result.routing_decision.agreement_score).toBeCloseTo(0.8, 6);
     });
 
     it('should set agreement_score to null when knowledge not used', async () => {


### PR DESCRIPTION
## Summary
- refactor knowledge storage to use raw scores with lazy exponential decay at read time, incremental stats hashes, indexed pruning, and guard against Redis KEYS
- update token Redis store to rely on explicit indexes instead of KEYS, deprecate manual decay endpoint, and document the lazy decay/incremental stats model with new environment configuration
- refresh tests for decay behavior, stats aggregation, and model validation tolerances

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945778c4ee48325aba4c828e753d5f3)