### PR TITLE
Feat/ranked routing

### DIFF
--- a/src/cache/semantic-cache.ts
+++ b/src/cache/semantic-cache.ts
@@ -77,21 +77,31 @@ export class SemanticCache {
         },
       });
 
-      // LangCache returns null or undefined if no match found
-      // The response field contains the cached data
-      if (!result || !(result as any).response) {
+      // LangCache returns { data: [{ response, similarity, ... }] } structure
+      // Check if we have data array with at least one result
+      const data = (result as any)?.data;
+      if (!result || !data || !Array.isArray(data) || data.length === 0 || !data[0]?.response) {
         console.log('LangCache search() returned no match:', {
           result_is_null: result === null,
           result_is_undefined: result === undefined,
-          result_has_response: result && !!(result as any).response,
+          has_data: !!data,
+          is_array: Array.isArray(data),
+          data_length: data?.length || 0,
+          has_response: data?.[0]?.response ? true : false,
           prompt_hash: this.hashPrompt(prompt),
         });
         this.stats.misses++;
         return null;
       }
 
-      // Parse cached response (stored as JSON string)
-      const cachedDecision = JSON.parse((result as any).response) as RankedRouteDecision;
+      // Parse cached response from first result (stored as JSON string)
+      const cachedDecision = JSON.parse(data[0].response) as RankedRouteDecision;
+      console.log('LangCache cache hit!', {
+        prompt_hash: this.hashPrompt(prompt),
+        similarity: data[0].similarity,
+        searchStrategy: data[0].searchStrategy,
+        top_model: cachedDecision.ranked_models[0]?.model,
+      });
       this.stats.hits++;
 
       return cachedDecision;

--- a/test/cache/semantic-cache.test.ts
+++ b/test/cache/semantic-cache.test.ts
@@ -80,8 +80,18 @@ describe('Global Semantic Cache', () => {
         ],
       };
 
+      // LangCache returns { data: [{ response, similarity, ... }] } structure
       mockLangCacheClient.search.mockResolvedValue({
-        response: JSON.stringify(cachedDecision),
+        data: [
+          {
+            id: 'test-id',
+            prompt: 'test prompt',
+            response: JSON.stringify(cachedDecision),
+            attributes: {},
+            similarity: 1,
+            searchStrategy: 'semantic',
+          },
+        ],
       });
 
       const result = await cache.get('test prompt');
@@ -175,7 +185,16 @@ describe('Global Semantic Cache', () => {
     it('should return cache statistics with correct hit rate', async () => {
       // Simulate 3 cache hits
       mockLangCacheClient.search.mockResolvedValue({
-        response: JSON.stringify({ intent: 'test', ranked_models: [{ rank: 1, model: 'gpt-4', score: 8, reason: 'test' }] }),
+        data: [
+          {
+            id: 'test-id',
+            prompt: 'test',
+            response: JSON.stringify({ intent: 'test', ranked_models: [{ rank: 1, model: 'gpt-4', score: 8, reason: 'test' }] }),
+            attributes: {},
+            similarity: 1,
+            searchStrategy: 'semantic',
+          },
+        ],
       });
       await cache.get('p1');
       await cache.get('p2');
@@ -227,7 +246,16 @@ describe('Global Semantic Cache', () => {
 
       // First request: "process a csv file"
       mockLangCacheClient.search.mockResolvedValue({
-        response: JSON.stringify(decision),
+        data: [
+          {
+            id: 'test-id-1',
+            prompt: 'process a csv file',
+            response: JSON.stringify(decision),
+            attributes: {},
+            similarity: 1,
+            searchStrategy: 'semantic',
+          },
+        ],
       });
 
       const result1 = await cache.get('process a csv file');
@@ -236,7 +264,16 @@ describe('Global Semantic Cache', () => {
       // Second request: "analyze a csv file" (semantically similar)
       // LangCache would return the same cached decision due to semantic similarity
       mockLangCacheClient.search.mockResolvedValue({
-        response: JSON.stringify(decision),
+        data: [
+          {
+            id: 'test-id-1',
+            prompt: 'process a csv file',
+            response: JSON.stringify(decision),
+            attributes: {},
+            similarity: 0.95,
+            searchStrategy: 'semantic',
+          },
+        ],
       });
 
       const result2 = await cache.get('analyze a csv file');
@@ -268,7 +305,16 @@ describe('Global Semantic Cache', () => {
       };
 
       mockLangCacheClient.search.mockResolvedValue({
-        response: JSON.stringify(decision),
+        data: [
+          {
+            id: 'test-id',
+            prompt: 'same prompt',
+            response: JSON.stringify(decision),
+            attributes: {},
+            similarity: 1,
+            searchStrategy: 'semantic',
+          },
+        ],
       });
 
       // Any token can retrieve it (no token_id in cache key)


### PR DESCRIPTION
 The Problem

  The code was checking for result.response, but LangCache actually returns the response in a nested structure: result.data[0].response. This caused every cache lookup to fail even when LangCache found a perfect match (similarity: 1.0).

  The Fix

  Updated src/cache/semantic-cache.ts:82-105 to:
  1. Check for result.data array instead of result.response
  2. Access the response from data[0].response
  3. Added logging to show cache hits with similarity and searchStrategy

  What Changed

  Before:
  if (!result || !(result as any).response) {
    // Always returned null, even for perfect matches!

  After:
  const data = (result as any)?.data;
  if (!result || !data || !Array.isArray(data) || data.length === 0 || !data[0]?.response) {
    // Correctly checks LangCache API response structure

  Impact

  - ✅ Cache will now work correctly
  - ✅ Identical/similar prompts will hit cache instead of calling LLM
  - ✅ Major cost savings and latency improvement
  - ✅ All 381 tests passing