### PR TITLE
PR2: Integrate provider adapter and add compatibility retries

### DIFF
--- a/docs/design/TODO.md
+++ b/docs/design/TODO.md
@@ -122,7 +122,7 @@
 - Routing success rate > 99% (excluding downstream provider outages).
 
 ### Execution Plan (PR-by-PR)
-- [ ] **PR1: Config + contracts + adapter scaffolding (no behavior change)**
+- [x] **PR1: Config + contracts + adapter scaffolding (no behavior change)**
   - Add reliability config contract/env parsing:
     - `ROUTER_PREFLIGHT_MODE`
     - `ROUTER_PREFLIGHT_TIMEOUT_MS`
@@ -135,7 +135,7 @@
   - Add provider-health types/store scaffolding (in-memory + Redis interface contract only).
   - Update tests for new config fields and defaults.
   - Gate: build + existing routing tests pass.
-- [ ] **PR2: Provider adapter integration + compatibility retry**
+- [x] **PR2: Provider adapter integration + compatibility retry**
   - Wire OpenAI/Gemini clients through adapter request-building.
   - Add one-shot compatibility retry for known contract errors.
   - Add unit tests for retry transformation paths.

--- a/src/routing/router-llm/providers/gemini-client.ts
+++ b/src/routing/router-llm/providers/gemini-client.ts
@@ -76,10 +76,10 @@ const ROUTER_RESPONSE_SCHEMA: Record<string, unknown> = {
  * Gemini error response structure
  */
 interface GeminiErrorResponse {
-  error: {
-    code: number;
-    message: string;
-    status: string;
+  error?: {
+    code?: number;
+    message?: string;
+    status?: string;
     details?: unknown[];
   };
 }
@@ -112,6 +112,12 @@ export class GeminiClient implements ProviderClient {
     const debugEnabled = process.env.ROUTER_LLM_DEBUG === 'true';
     const compatRetryEnabled = process.env.ROUTER_COMPAT_RETRY_ENABLED !== 'false';
     const plan = buildProviderInvocationPlan('gemini', request);
+    const debugGenerationConfig = {
+      temperature: request.temperature,
+      maxOutputTokens: request.maxTokens,
+      responseMimeType: plan.jsonResponseMode === 'native_json' ? 'application/json' : undefined,
+      responseSchemaIncluded: plan.jsonSchemaMode === 'provider_schema',
+    };
 
     // Create abort controller for timeout
     const controller = new AbortController();
@@ -256,11 +262,7 @@ export class GeminiClient implements ProviderClient {
       if (debugEnabled) {
         console.error('[gemini] Unexpected provider error', {
           model: request.model,
-          generationConfig: {
-            temperature: request.temperature,
-            maxOutputTokens: request.maxTokens,
-            responseMimeType: 'application/json',
-          },
+          generationConfig: debugGenerationConfig,
           error: error instanceof Error ? { name: error.name, message: error.message, stack: error.stack } : String(error),
         });
       }

--- a/src/routing/router-llm/providers/gemini-client.ts
+++ b/src/routing/router-llm/providers/gemini-client.ts
@@ -119,7 +119,8 @@ export class GeminiClient implements ProviderClient {
 
     try {
       const url = `${this.baseUrl}/models/${request.model}:generateContent`;
-      const schemaAttempts = compatRetryEnabled ? [true, false] : [true];
+      const canRetryWithoutSchema = compatRetryEnabled && plan.jsonSchemaMode === 'provider_schema';
+      const schemaAttempts = canRetryWithoutSchema ? [true, false] : [true];
       let data: GeminiResponse | undefined;
       let responseStatus: number | undefined;
       let lastProviderError: RouterLLMProviderError | undefined;

--- a/src/routing/router-llm/providers/gemini-client.ts
+++ b/src/routing/router-llm/providers/gemini-client.ts
@@ -120,9 +120,8 @@ export class GeminiClient implements ProviderClient {
     try {
       const url = `${this.baseUrl}/models/${request.model}:generateContent`;
       const canRetryWithoutSchema = compatRetryEnabled && plan.jsonSchemaMode === 'provider_schema';
-      const schemaAttempts = canRetryWithoutSchema ? [true, false] : [true];
+      const schemaAttempts: [true] | [true, false] = canRetryWithoutSchema ? [true, false] : [true];
       let data: GeminiResponse | undefined;
-      let responseStatus: number | undefined;
       let lastProviderError: RouterLLMProviderError | undefined;
 
       for (let index = 0; index < schemaAttempts.length; index += 1) {
@@ -159,8 +158,6 @@ export class GeminiClient implements ProviderClient {
           signal: controller.signal,
         });
 
-        responseStatus = response.status;
-
         if (!response.ok) {
           const errorData = (await response.json()) as GeminiErrorResponse;
           if (debugEnabled) {
@@ -178,9 +175,8 @@ export class GeminiClient implements ProviderClient {
           }
           const message = errorData.error?.message ?? `Gemini API status ${response.status}`;
           const retryableCompatibilityError =
-            includeSchema &&
             index === 0 &&
-            compatRetryEnabled &&
+            canRetryWithoutSchema &&
             this.shouldRetryWithoutSchema(message, response.status);
           if (retryableCompatibilityError) {
             continue;
@@ -205,9 +201,8 @@ export class GeminiClient implements ProviderClient {
           throw lastProviderError;
         }
         throw new RouterLLMProviderError(
-          'Gemini API returned no usable response',
-          'gemini',
-          responseStatus
+          'Gemini client invariant violated: compatibility attempts completed without response or provider error',
+          'gemini'
         );
       }
 

--- a/src/routing/router-llm/providers/gemini-client.ts
+++ b/src/routing/router-llm/providers/gemini-client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ProviderClient, ProviderRequest, ProviderResponse } from './types';
+import { buildProviderInvocationPlan } from '../provider-adapter';
 import {
   RouterLLMProviderError,
   RouterLLMTimeoutError,
@@ -96,77 +97,118 @@ export class GeminiClient implements ProviderClient {
     return 'gemini';
   }
 
+  private shouldRetryWithoutSchema(message: string, status: number): boolean {
+    if (status !== 400) {
+      return false;
+    }
+    const lower = message.toLowerCase();
+    return lower.includes('additionalproperties') ||
+      lower.includes('response_schema') ||
+      lower.includes('responseschema');
+  }
+
   async invoke(request: ProviderRequest): Promise<ProviderResponse> {
     const startTime = Date.now();
     const debugEnabled = process.env.ROUTER_LLM_DEBUG === 'true';
+    const compatRetryEnabled = process.env.ROUTER_COMPAT_RETRY_ENABLED !== 'false';
+    const plan = buildProviderInvocationPlan('gemini', request);
 
     // Create abort controller for timeout
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), request.timeout);
 
     try {
-      // Build Gemini request
-      const body: GeminiRequest = {
-        contents: [
-          {
-            parts: [
-              {
-                text: request.prompt,
-              },
-            ],
-          },
-        ],
-        generationConfig: {
-          temperature: request.temperature,
-          maxOutputTokens: request.maxTokens,
-          responseMimeType: 'application/json', // Request JSON response
-          responseSchema: ROUTER_RESPONSE_SCHEMA,
-        },
-      };
-
-      // Make API request
-      // Use header-based authentication (x-goog-api-key) instead of query parameter
-      // to avoid exposing API key in URLs, server logs, and browser history
       const url = `${this.baseUrl}/models/${request.model}:generateContent`;
+      const schemaAttempts = compatRetryEnabled ? [true, false] : [true];
+      let data: GeminiResponse | undefined;
+      let responseStatus: number | undefined;
+      let lastProviderError: RouterLLMProviderError | undefined;
 
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-goog-api-key': this.apiKey,
-        },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
+      for (let index = 0; index < schemaAttempts.length; index += 1) {
+        const includeSchema = schemaAttempts[index];
+        const body: GeminiRequest = {
+          contents: [
+            {
+              parts: [
+                {
+                  text: request.prompt,
+                },
+              ],
+            },
+          ],
+          generationConfig: {
+            temperature: request.temperature,
+            maxOutputTokens: request.maxTokens,
+            ...(plan.jsonResponseMode === 'native_json'
+              ? { responseMimeType: 'application/json' }
+              : {}),
+            ...(plan.jsonSchemaMode === 'provider_schema' && includeSchema
+              ? { responseSchema: ROUTER_RESPONSE_SCHEMA }
+              : {}),
+          },
+        };
+
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-goog-api-key': this.apiKey,
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+
+        responseStatus = response.status;
+
+        if (!response.ok) {
+          const errorData = (await response.json()) as GeminiErrorResponse;
+          if (debugEnabled) {
+            console.error('[gemini] Provider request failed', {
+              status: response.status,
+              model: request.model,
+              generationConfig: body.generationConfig,
+              error: {
+                code: errorData.error?.code,
+                status: errorData.error?.status,
+                message: errorData.error?.message,
+                details: errorData.error?.details,
+              },
+            });
+          }
+          const message = errorData.error?.message ?? `Gemini API status ${response.status}`;
+          const retryableCompatibilityError =
+            includeSchema &&
+            index === 0 &&
+            compatRetryEnabled &&
+            this.shouldRetryWithoutSchema(message, response.status);
+          if (retryableCompatibilityError) {
+            continue;
+          }
+          lastProviderError = new RouterLLMProviderError(
+            `Gemini API error: ${message}`,
+            'gemini',
+            response.status,
+            errorData.error?.code !== undefined ? new Error(String(errorData.error.code)) : undefined
+          );
+          break;
+        }
+
+        data = (await response.json()) as GeminiResponse;
+        break;
+      }
 
       clearTimeout(timeoutId);
 
-      // Handle error responses
-      if (!response.ok) {
-        const errorData = (await response.json()) as GeminiErrorResponse;
-        if (debugEnabled) {
-          console.error('[gemini] Provider request failed', {
-            status: response.status,
-            model: request.model,
-            generationConfig: body.generationConfig,
-            error: {
-              code: errorData.error?.code,
-              status: errorData.error?.status,
-              message: errorData.error?.message,
-              details: errorData.error?.details,
-            },
-          });
+      if (!data) {
+        if (lastProviderError) {
+          throw lastProviderError;
         }
         throw new RouterLLMProviderError(
-          `Gemini API error: ${errorData.error.message}`,
+          'Gemini API returned no usable response',
           'gemini',
-          response.status,
-          errorData.error.code !== undefined ? new Error(String(errorData.error.code)) : undefined
+          responseStatus
         );
       }
-
-      // Parse successful response
-      const data = (await response.json()) as GeminiResponse;
 
       // Extract response text
       if (!data.candidates || data.candidates.length === 0) {

--- a/src/routing/router-llm/providers/gemini-client.ts
+++ b/src/routing/router-llm/providers/gemini-client.ts
@@ -118,20 +118,22 @@ export class GeminiClient implements ProviderClient {
       responseMimeType: plan.jsonResponseMode === 'native_json' ? 'application/json' : undefined,
       responseSchemaIncluded: plan.jsonSchemaMode === 'provider_schema',
     };
+    let lastGenerationConfig: GeminiRequest['generationConfig'] | undefined;
 
-    // Create abort controller for timeout
+    // Use a single timeout budget across compatibility retries for this invocation.
+    // This enforces per-operation timeout instead of per-attempt timeout.
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), request.timeout);
 
     try {
       const url = `${this.baseUrl}/models/${request.model}:generateContent`;
       const canRetryWithoutSchema = compatRetryEnabled && plan.jsonSchemaMode === 'provider_schema';
-      const schemaAttempts: [true] | [true, false] = canRetryWithoutSchema ? [true, false] : [true];
+      const maxAttempts = canRetryWithoutSchema ? 2 : 1;
       let data: GeminiResponse | undefined;
       let lastProviderError: RouterLLMProviderError | undefined;
 
-      for (let index = 0; index < schemaAttempts.length; index += 1) {
-        const includeSchema = schemaAttempts[index];
+      for (let index = 0; index < maxAttempts; index += 1) {
+        const includeSchema = index === 0;
         const body: GeminiRequest = {
           contents: [
             {
@@ -153,6 +155,7 @@ export class GeminiClient implements ProviderClient {
               : {}),
           },
         };
+        lastGenerationConfig = body.generationConfig;
 
         const response = await fetch(url, {
           method: 'POST',
@@ -262,7 +265,7 @@ export class GeminiClient implements ProviderClient {
       if (debugEnabled) {
         console.error('[gemini] Unexpected provider error', {
           model: request.model,
-          generationConfig: debugGenerationConfig,
+          generationConfig: lastGenerationConfig ?? debugGenerationConfig,
           error: error instanceof Error ? { name: error.name, message: error.message, stack: error.stack } : String(error),
         });
       }

--- a/src/routing/router-llm/providers/openai-client.ts
+++ b/src/routing/router-llm/providers/openai-client.ts
@@ -7,6 +7,7 @@
 
 import type { ProviderClient, ProviderRequest, ProviderResponse } from './types';
 import { buildProviderInvocationPlan } from '../provider-adapter';
+import type { TokenLimitParameter } from '../capabilities';
 import {
   RouterLLMProviderError,
   RouterLLMTimeoutError,
@@ -93,20 +94,19 @@ export class OpenAIClient implements ProviderClient {
     const timeoutId = setTimeout(() => controller.abort(), request.timeout);
 
     try {
-      const tokenParameterAttempts = [plan.tokenLimitParameter];
+      const tokenParameterAttempts: TokenLimitParameter[] = [plan.tokenLimitParameter];
       if (compatRetryEnabled) {
         tokenParameterAttempts.push(
           plan.tokenLimitParameter === 'max_tokens' ? 'max_completion_tokens' : 'max_tokens'
         );
       }
-      const uniqueTokenParameterAttempts = Array.from(new Set(tokenParameterAttempts));
 
       let data: OpenAIResponse | undefined;
       let responseStatus: number | undefined;
       let lastProviderError: RouterLLMProviderError | undefined;
 
-      for (let index = 0; index < uniqueTokenParameterAttempts.length; index += 1) {
-        const tokenParam = uniqueTokenParameterAttempts[index];
+      for (let index = 0; index < tokenParameterAttempts.length; index += 1) {
+        const tokenParam = tokenParameterAttempts[index];
         const body: OpenAIRequest = {
           model: request.model,
           messages: [

--- a/src/routing/router-llm/providers/openai-client.ts
+++ b/src/routing/router-llm/providers/openai-client.ts
@@ -55,9 +55,9 @@ interface OpenAIResponse {
  * OpenAI error response structure
  */
 interface OpenAIErrorResponse {
-  error: {
-    message: string;
-    type: string;
+  error?: {
+    message?: string;
+    type?: string;
     code?: string;
   };
 }
@@ -89,7 +89,8 @@ export class OpenAIClient implements ProviderClient {
     const compatRetryEnabled = process.env.ROUTER_COMPAT_RETRY_ENABLED !== 'false';
     const plan = buildProviderInvocationPlan('openai', request);
 
-    // Create abort controller for timeout
+    // Use a single timeout budget across compatibility retries for this invocation.
+    // This enforces per-operation timeout instead of per-attempt timeout.
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), request.timeout);
 

--- a/src/routing/router-llm/providers/openai-client.ts
+++ b/src/routing/router-llm/providers/openai-client.ts
@@ -94,7 +94,7 @@ export class OpenAIClient implements ProviderClient {
     const timeoutId = setTimeout(() => controller.abort(), request.timeout);
 
     try {
-      const tokenParameterAttempts: TokenLimitParameter[] = [plan.tokenLimitParameter];
+      const tokenParameterAttempts: [TokenLimitParameter, ...TokenLimitParameter[]] = [plan.tokenLimitParameter];
       if (compatRetryEnabled) {
         tokenParameterAttempts.push(
           plan.tokenLimitParameter === 'max_tokens' ? 'max_completion_tokens' : 'max_tokens'
@@ -119,6 +119,8 @@ export class OpenAIClient implements ProviderClient {
           ...(tokenParam === 'max_completion_tokens'
             ? { max_completion_tokens: request.maxTokens }
             : { max_tokens: request.maxTokens }),
+          // Intentionally conditional: future capability profiles may disable
+          // provider-native JSON mode for specific OpenAI model families.
           ...(plan.jsonResponseMode === 'native_json' ? { response_format: { type: 'json_object' as const } } : {}),
         };
 
@@ -163,9 +165,8 @@ export class OpenAIClient implements ProviderClient {
           throw lastProviderError;
         }
         throw new RouterLLMProviderError(
-          'OpenAI API returned no usable response',
-          'openai',
-          responseStatus
+          'OpenAI client invariant violated: compatibility attempts completed without response or provider error',
+          'openai'
         );
       }
 

--- a/src/routing/router-llm/providers/openai-client.ts
+++ b/src/routing/router-llm/providers/openai-client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ProviderClient, ProviderRequest, ProviderResponse } from './types';
+import { buildProviderInvocationPlan } from '../provider-adapter';
 import {
   RouterLLMProviderError,
   RouterLLMTimeoutError,
@@ -21,7 +22,8 @@ interface OpenAIRequest {
     content: string;
   }>;
   temperature: number;
-  max_tokens: number;
+  max_tokens?: number;
+  max_completion_tokens?: number;
   response_format?: { type: 'json_object' };
 }
 
@@ -72,53 +74,100 @@ export class OpenAIClient implements ProviderClient {
     return 'openai';
   }
 
+  private shouldRetryForTokenParameterCompatibility(message: string, status: number): boolean {
+    if (status !== 400) {
+      return false;
+    }
+    const lower = message.toLowerCase();
+    return lower.includes('unsupported parameter') &&
+      (lower.includes('max_tokens') || lower.includes('max_completion_tokens'));
+  }
+
   async invoke(request: ProviderRequest): Promise<ProviderResponse> {
     const startTime = Date.now();
+    const compatRetryEnabled = process.env.ROUTER_COMPAT_RETRY_ENABLED !== 'false';
+    const plan = buildProviderInvocationPlan('openai', request);
 
     // Create abort controller for timeout
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), request.timeout);
 
     try {
-      // Build OpenAI request
-      const body: OpenAIRequest = {
-        model: request.model,
-        messages: [
-          {
-            role: 'user',
-            content: request.prompt,
-          },
-        ],
-        temperature: request.temperature,
-        max_tokens: request.maxTokens,
-        response_format: { type: 'json_object' },
-      };
+      const tokenParameterAttempts = [plan.tokenLimitParameter];
+      if (compatRetryEnabled) {
+        tokenParameterAttempts.push(
+          plan.tokenLimitParameter === 'max_tokens' ? 'max_completion_tokens' : 'max_tokens'
+        );
+      }
+      const uniqueTokenParameterAttempts = Array.from(new Set(tokenParameterAttempts));
 
-      // Make API request
-      const response = await fetch(`${this.baseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.apiKey}`,
-        },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
+      let data: OpenAIResponse | undefined;
+      let responseStatus: number | undefined;
+      let lastProviderError: RouterLLMProviderError | undefined;
+
+      for (let index = 0; index < uniqueTokenParameterAttempts.length; index += 1) {
+        const tokenParam = uniqueTokenParameterAttempts[index];
+        const body: OpenAIRequest = {
+          model: request.model,
+          messages: [
+            {
+              role: 'user',
+              content: request.prompt,
+            },
+          ],
+          temperature: request.temperature,
+          ...(tokenParam === 'max_completion_tokens'
+            ? { max_completion_tokens: request.maxTokens }
+            : { max_tokens: request.maxTokens }),
+          ...(plan.jsonResponseMode === 'native_json' ? { response_format: { type: 'json_object' as const } } : {}),
+        };
+
+        const response = await fetch(`${this.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+
+        responseStatus = response.status;
+
+        if (!response.ok) {
+          const errorData = (await response.json()) as OpenAIErrorResponse;
+          const message = errorData.error?.message ?? `OpenAI API status ${response.status}`;
+          const retryableCompatibilityError =
+            index === 0 &&
+            compatRetryEnabled &&
+            this.shouldRetryForTokenParameterCompatibility(message, response.status);
+          if (retryableCompatibilityError) {
+            continue;
+          }
+          lastProviderError = new RouterLLMProviderError(
+            `OpenAI API error: ${message}`,
+            'openai',
+            response.status
+          );
+          break;
+        }
+
+        data = (await response.json()) as OpenAIResponse;
+        break;
+      }
 
       clearTimeout(timeoutId);
 
-      // Handle error responses
-      if (!response.ok) {
-        const errorData = (await response.json()) as OpenAIErrorResponse;
+      if (!data) {
+        if (lastProviderError) {
+          throw lastProviderError;
+        }
         throw new RouterLLMProviderError(
-          `OpenAI API error: ${errorData.error.message}`,
+          'OpenAI API returned no usable response',
           'openai',
-          response.status
+          responseStatus
         );
       }
-
-      // Parse successful response
-      const data = (await response.json()) as OpenAIResponse;
 
       // Extract content from first choice
       const choice = data.choices[0];
@@ -126,7 +175,7 @@ export class OpenAIClient implements ProviderClient {
         throw new RouterLLMProviderError(
           'OpenAI API returned empty choices array',
           'openai',
-          response.status
+          responseStatus
         );
       }
 
@@ -135,7 +184,7 @@ export class OpenAIClient implements ProviderClient {
         throw new RouterLLMProviderError(
           'OpenAI API returned empty response',
           'openai',
-          response.status
+          responseStatus
         );
       }
 

--- a/test/routing/providers.test.ts
+++ b/test/routing/providers.test.ts
@@ -151,6 +151,67 @@ describe('OpenAIClient', () => {
     await expect(client.invoke(request)).rejects.toThrow(RouterLLMProviderError);
     await expect(client.invoke(request)).rejects.toThrow('empty choices');
   });
+
+  it('retries once with compatibility token parameter on OpenAI contract errors', async () => {
+    const mockResponse = {
+      id: 'chatcmpl-123',
+      object: 'chat.completion',
+      created: 1677652288,
+      model: 'gpt-4o',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: '{"intent":"test","ranked_models":[{"rank":1,"model":"gpt-4o","score":9,"reason":"test"}]}',
+          },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+      },
+    };
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+            type: 'invalid_request_error',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      });
+    global.fetch = fetchMock;
+
+    const request: ProviderRequest = {
+      prompt: 'Test prompt',
+      model: 'gpt-4o',
+      temperature: 0.0,
+      maxTokens: 500,
+      timeout: 10000,
+    };
+
+    const response = await client.invoke(request);
+    expect(response.metadata.provider).toBe('openai');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const firstBody = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
+    const secondBody = JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string);
+    expect(firstBody.max_tokens).toBe(500);
+    expect(firstBody.max_completion_tokens).toBeUndefined();
+    expect(secondBody.max_tokens).toBeUndefined();
+    expect(secondBody.max_completion_tokens).toBe(500);
+  });
 });
 
 describe('AnthropicClient', () => {
@@ -435,6 +496,68 @@ describe('GeminiClient', () => {
 
     await expect(client.invoke(request)).rejects.toThrow(RouterLLMProviderError);
     await expect(client.invoke(request)).rejects.toThrow('no candidates');
+  });
+
+  it('retries once without responseSchema on Gemini schema compatibility errors', async () => {
+    const mockResponse = {
+      candidates: [
+        {
+          content: {
+            role: 'model',
+            parts: [
+              {
+                text: '{"intent":"test","ranked_models":[{"rank":1,"model":"gpt-4o","score":9,"reason":"test"}]}',
+              },
+            ],
+          },
+          finishReason: 'STOP',
+          index: 0,
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      },
+      modelVersion: 'gemini-1.5-flash',
+    };
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            code: 400,
+            message: 'Invalid JSON payload received. Unknown name "additionalProperties"',
+            status: 'INVALID_ARGUMENT',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockResponse,
+      });
+    global.fetch = fetchMock;
+
+    const request: ProviderRequest = {
+      prompt: 'Test prompt',
+      model: 'gemini-1.5-flash',
+      temperature: 0.0,
+      maxTokens: 500,
+      timeout: 10000,
+    };
+
+    const response = await client.invoke(request);
+    expect(response.metadata.provider).toBe('gemini');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const firstBody = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
+    const secondBody = JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string);
+    expect(firstBody.generationConfig.responseSchema).toBeDefined();
+    expect(secondBody.generationConfig.responseSchema).toBeUndefined();
+    expect(secondBody.generationConfig.responseMimeType).toBe('application/json');
   });
 });
 

--- a/test/routing/providers.test.ts
+++ b/test/routing/providers.test.ts
@@ -212,6 +212,78 @@ describe('OpenAIClient', () => {
     expect(secondBody.max_tokens).toBeUndefined();
     expect(secondBody.max_completion_tokens).toBe(500);
   });
+
+  it('does not retry compatibility when ROUTER_COMPAT_RETRY_ENABLED=false', async () => {
+    const previous = process.env.ROUTER_COMPAT_RETRY_ENABLED;
+    process.env.ROUTER_COMPAT_RETRY_ENABLED = 'false';
+
+    try {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+            type: 'invalid_request_error',
+          },
+        }),
+      });
+      global.fetch = fetchMock;
+
+      const request: ProviderRequest = {
+        prompt: 'Test prompt',
+        model: 'gpt-4o',
+        temperature: 0.0,
+        maxTokens: 500,
+        timeout: 10000,
+      };
+
+      await expect(client.invoke(request)).rejects.toThrow('Unsupported parameter');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ROUTER_COMPAT_RETRY_ENABLED;
+      } else {
+        process.env.ROUTER_COMPAT_RETRY_ENABLED = previous;
+      }
+    }
+  });
+
+  it('throws provider error when compatibility retry attempt also fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+            type: 'invalid_request_error',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            message: 'Still invalid after compatibility retry',
+            type: 'invalid_request_error',
+          },
+        }),
+      });
+    global.fetch = fetchMock;
+
+    const request: ProviderRequest = {
+      prompt: 'Test prompt',
+      model: 'gpt-4o',
+      temperature: 0.0,
+      maxTokens: 500,
+      timeout: 10000,
+    };
+
+    await expect(client.invoke(request)).rejects.toThrow('Still invalid after compatibility retry');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('AnthropicClient', () => {
@@ -555,9 +627,85 @@ describe('GeminiClient', () => {
 
     const firstBody = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
     const secondBody = JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string);
+    expect(firstBody.generationConfig.responseMimeType).toBe('application/json');
     expect(firstBody.generationConfig.responseSchema).toBeDefined();
     expect(secondBody.generationConfig.responseSchema).toBeUndefined();
     expect(secondBody.generationConfig.responseMimeType).toBe('application/json');
+  });
+
+  it('does not retry schema compatibility when ROUTER_COMPAT_RETRY_ENABLED=false', async () => {
+    const previous = process.env.ROUTER_COMPAT_RETRY_ENABLED;
+    process.env.ROUTER_COMPAT_RETRY_ENABLED = 'false';
+
+    try {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            code: 400,
+            message: 'Invalid JSON payload received. Unknown name "additionalProperties"',
+            status: 'INVALID_ARGUMENT',
+          },
+        }),
+      });
+      global.fetch = fetchMock;
+
+      const request: ProviderRequest = {
+        prompt: 'Test prompt',
+        model: 'gemini-1.5-flash',
+        temperature: 0.0,
+        maxTokens: 500,
+        timeout: 10000,
+      };
+
+      await expect(client.invoke(request)).rejects.toThrow('Unknown name "additionalProperties"');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ROUTER_COMPAT_RETRY_ENABLED;
+      } else {
+        process.env.ROUTER_COMPAT_RETRY_ENABLED = previous;
+      }
+    }
+  });
+
+  it('throws provider error when schema-compat retry also fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            code: 400,
+            message: 'Invalid JSON payload received. Unknown name "additionalProperties"',
+            status: 'INVALID_ARGUMENT',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: {
+            code: 400,
+            message: 'Schema-less retry still failed',
+            status: 'INVALID_ARGUMENT',
+          },
+        }),
+      });
+    global.fetch = fetchMock;
+
+    const request: ProviderRequest = {
+      prompt: 'Test prompt',
+      model: 'gemini-1.5-flash',
+      temperature: 0.0,
+      maxTokens: 500,
+      timeout: 10000,
+    };
+
+    await expect(client.invoke(request)).rejects.toThrow('Schema-less retry still failed');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- wire provider adapter planning into OpenAI and Gemini provider clients
- add one-shot compatibility retry for OpenAI token-parameter contract errors (max_tokens <-> max_completion_tokens)
- add one-shot Gemini retry without responseSchema for known schema compatibility payload errors
- keep retry behavior bounded and opt-out capable via ROUTER_COMPAT_RETRY_ENABLED=false
- extend provider tests with explicit compatibility-retry coverage for both providers

## Notes
- this is PR2 from the router reliability execution plan
- no circuit breaker or startup preflight behavior in this PR (those are next phases)

## Testing
- npm run build
- npm test -- test/routing/providers.test.ts test/routing/config.test.ts test/routing/capabilities.test.ts