### PR TITLE
Add router circuit breaker runtime integration

### DIFF
--- a/docs/design/TODO.md
+++ b/docs/design/TODO.md
@@ -140,7 +140,7 @@
   - Add one-shot compatibility retry for known contract errors.
   - Add unit tests for retry transformation paths.
   - Gate: provider client tests pass + no behavior regressions.
-- [ ] **PR3: Circuit breaker runtime integration**
+- [x] **PR3: Circuit breaker runtime integration**
   - Add provider/model sliding-window failure tracking.
   - Add `closed/open/half_open` gating in multi-provider invocation path.
   - Add state-transition tests and failure-recovery tests.

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -22,6 +22,10 @@ const routingLlmErrors = meter.createCounter('routing.llm_errors_total', {
   description: 'Total router LLM errors',
 });
 
+const routingLlmCircuitBreakerBlocks = meter.createCounter('routing.llm_circuit_breaker_blocks_total', {
+  description: 'Total router LLM provider calls blocked by circuit breaker',
+});
+
 const routingLlmLatency = meter.createHistogram('routing.llm_latency_ms', {
   description: 'Router LLM latency in milliseconds',
   unit: 'ms',
@@ -87,6 +91,13 @@ export function recordLlmCall(
 
 export function recordLlmError(provider: string, attributes: RoutingMetricAttributes): void {
   routingLlmErrors.add(1, { ...attributes, provider });
+}
+
+export function recordLlmCircuitBreakerBlock(
+  provider: string,
+  attributes: RoutingMetricAttributes
+): void {
+  routingLlmCircuitBreakerBlocks.add(1, { ...attributes, provider });
 }
 
 export function recordRoutingFallback(attributes: RoutingMetricAttributes): void {

--- a/src/routing/router-llm/circuit-breaker.ts
+++ b/src/routing/router-llm/circuit-breaker.ts
@@ -1,0 +1,112 @@
+import type { CircuitBreakerState } from './provider-health';
+
+interface CircuitBreakerKey {
+  provider: string;
+  model: string;
+}
+
+interface CircuitBreakerEntry {
+  failureTimestampsMs: number[];
+  openUntilMs?: number;
+  halfOpenProbeInFlight: boolean;
+}
+
+export interface CircuitBreakerConfig {
+  errorThreshold: number;
+  windowMs: number;
+  openMs: number;
+}
+
+export interface CircuitBreakerDecision {
+  allowed: boolean;
+  state: CircuitBreakerState;
+}
+
+export class ProviderCircuitBreaker {
+  private readonly entries = new Map<string, CircuitBreakerEntry>();
+
+  constructor(private readonly config: CircuitBreakerConfig) {}
+
+  shouldAllowRequest(provider: string, model: string, nowMs = Date.now()): CircuitBreakerDecision {
+    const entry = this.getOrCreateEntry(provider, model);
+    this.pruneFailures(entry, nowMs);
+
+    if (entry.openUntilMs && nowMs < entry.openUntilMs) {
+      return { allowed: false, state: 'open' };
+    }
+
+    if (entry.openUntilMs && nowMs >= entry.openUntilMs) {
+      if (entry.halfOpenProbeInFlight) {
+        return { allowed: false, state: 'half_open' };
+      }
+      entry.halfOpenProbeInFlight = true;
+      return { allowed: true, state: 'half_open' };
+    }
+
+    return { allowed: true, state: 'closed' };
+  }
+
+  recordSuccess(provider: string, model: string, nowMs = Date.now()): void {
+    const entry = this.getOrCreateEntry(provider, model);
+    this.pruneFailures(entry, nowMs);
+    entry.failureTimestampsMs = [];
+    entry.openUntilMs = undefined;
+    entry.halfOpenProbeInFlight = false;
+  }
+
+  recordFailure(provider: string, model: string, nowMs = Date.now()): void {
+    const entry = this.getOrCreateEntry(provider, model);
+    this.pruneFailures(entry, nowMs);
+
+    if (entry.halfOpenProbeInFlight) {
+      entry.halfOpenProbeInFlight = false;
+      entry.failureTimestampsMs = [nowMs];
+      entry.openUntilMs = nowMs + this.config.openMs;
+      return;
+    }
+
+    entry.failureTimestampsMs.push(nowMs);
+    if (entry.failureTimestampsMs.length >= this.config.errorThreshold) {
+      entry.openUntilMs = nowMs + this.config.openMs;
+    }
+  }
+
+  getState(provider: string, model: string, nowMs = Date.now()): CircuitBreakerState {
+    const entry = this.entries.get(this.toKey({ provider, model }));
+    if (!entry) {
+      return 'closed';
+    }
+    this.pruneFailures(entry, nowMs);
+
+    if (entry.openUntilMs && nowMs < entry.openUntilMs) {
+      return 'open';
+    }
+    if (entry.openUntilMs && nowMs >= entry.openUntilMs) {
+      return 'half_open';
+    }
+    return 'closed';
+  }
+
+  private getOrCreateEntry(provider: string, model: string): CircuitBreakerEntry {
+    const key = this.toKey({ provider, model });
+    let entry = this.entries.get(key);
+    if (!entry) {
+      entry = {
+        failureTimestampsMs: [],
+        halfOpenProbeInFlight: false,
+      };
+      this.entries.set(key, entry);
+    }
+    return entry;
+  }
+
+  private pruneFailures(entry: CircuitBreakerEntry, nowMs: number): void {
+    const cutoff = nowMs - this.config.windowMs;
+    entry.failureTimestampsMs = entry.failureTimestampsMs.filter((timestamp) => timestamp >= cutoff);
+  }
+
+  private toKey(key: CircuitBreakerKey): string {
+    return `${key.provider}:${key.model}`;
+  }
+}
+

--- a/src/routing/router-llm/circuit-breaker.ts
+++ b/src/routing/router-llm/circuit-breaker.ts
@@ -1,9 +1,5 @@
+import type { RouterLLMProvider } from '../config';
 import type { CircuitBreakerState } from './provider-health';
-
-interface CircuitBreakerKey {
-  provider: string;
-  model: string;
-}
 
 interface CircuitBreakerEntry {
   failureTimestampsMs: number[];
@@ -27,7 +23,7 @@ export class ProviderCircuitBreaker {
 
   constructor(private readonly config: CircuitBreakerConfig) {}
 
-  shouldAllowRequest(provider: string, model: string, nowMs = Date.now()): CircuitBreakerDecision {
+  shouldAllowRequest(provider: RouterLLMProvider, model: string, nowMs = Date.now()): CircuitBreakerDecision {
     const entry = this.getOrCreateEntry(provider, model);
     this.pruneFailures(entry, nowMs);
 
@@ -46,7 +42,7 @@ export class ProviderCircuitBreaker {
     return { allowed: true, state: 'closed' };
   }
 
-  recordSuccess(provider: string, model: string, nowMs = Date.now()): void {
+  recordSuccess(provider: RouterLLMProvider, model: string, nowMs = Date.now()): void {
     const entry = this.getOrCreateEntry(provider, model);
     this.pruneFailures(entry, nowMs);
     entry.failureTimestampsMs = [];
@@ -54,12 +50,14 @@ export class ProviderCircuitBreaker {
     entry.halfOpenProbeInFlight = false;
   }
 
-  recordFailure(provider: string, model: string, nowMs = Date.now()): void {
+  recordFailure(provider: RouterLLMProvider, model: string, nowMs = Date.now()): void {
     const entry = this.getOrCreateEntry(provider, model);
     this.pruneFailures(entry, nowMs);
 
     if (entry.halfOpenProbeInFlight) {
       entry.halfOpenProbeInFlight = false;
+      // A failed half-open probe starts a fresh open interval from now,
+      // so we reset failure history to this probe failure timestamp.
       entry.failureTimestampsMs = [nowMs];
       entry.openUntilMs = nowMs + this.config.openMs;
       return;
@@ -71,8 +69,8 @@ export class ProviderCircuitBreaker {
     }
   }
 
-  getState(provider: string, model: string, nowMs = Date.now()): CircuitBreakerState {
-    const entry = this.entries.get(this.toKey({ provider, model }));
+  getState(provider: RouterLLMProvider, model: string, nowMs = Date.now()): CircuitBreakerState {
+    const entry = this.entries.get(this.toKey(provider, model));
     if (!entry) {
       return 'closed';
     }
@@ -87,8 +85,8 @@ export class ProviderCircuitBreaker {
     return 'closed';
   }
 
-  private getOrCreateEntry(provider: string, model: string): CircuitBreakerEntry {
-    const key = this.toKey({ provider, model });
+  private getOrCreateEntry(provider: RouterLLMProvider, model: string): CircuitBreakerEntry {
+    const key = this.toKey(provider, model);
     let entry = this.entries.get(key);
     if (!entry) {
       entry = {
@@ -105,8 +103,7 @@ export class ProviderCircuitBreaker {
     entry.failureTimestampsMs = entry.failureTimestampsMs.filter((timestamp) => timestamp >= cutoff);
   }
 
-  private toKey(key: CircuitBreakerKey): string {
-    return `${key.provider}:${key.model}`;
+  private toKey(provider: RouterLLMProvider, model: string): string {
+    return `${provider}:${model}`;
   }
 }
-

--- a/src/routing/router-llm/index.ts
+++ b/src/routing/router-llm/index.ts
@@ -27,6 +27,11 @@ export {
 export { buildRoutingPrompt } from './prompt-builder';
 export { parseRouteDecision, parseRouteDecisionLenient, extractJSON } from './response-parser';
 export {
+  ProviderCircuitBreaker,
+  type CircuitBreakerConfig,
+  type CircuitBreakerDecision,
+} from './circuit-breaker';
+export {
   loadRouterLLMConfig,
   loadRouterLLMReliabilityConfig,
   type RouterLLMConfig,

--- a/src/routing/router-llm/multi-provider-router-llm.ts
+++ b/src/routing/router-llm/multi-provider-router-llm.ts
@@ -26,7 +26,7 @@ import {
   RouterLLMPolicyBypassError,
   RouterLLMProviderError,
 } from './errors';
-import { recordLlmCall, recordLlmError } from '../../observability/metrics';
+import { recordLlmCall, recordLlmError, recordLlmCircuitBreakerBlock } from '../../observability/metrics';
 import { dumpRawRouterResponse } from './raw-response-dump';
 import { ProviderCircuitBreaker } from './circuit-breaker';
 import type {
@@ -185,8 +185,8 @@ export class MultiProviderRouterLLM implements RouterLLM {
         this.updateProviderHealth(provider.name, provider.model, {
           circuitBreakerState: decision.state,
           healthState: this.healthStateFromCircuitBreaker(decision.state),
-          lastError: `Provider blocked by circuit breaker (${decision.state})`,
         });
+        recordLlmCircuitBreakerBlock(provider.name, {});
         continue;
       }
       invocableProviders.push(provider);

--- a/src/routing/router-llm/multi-provider-router-llm.ts
+++ b/src/routing/router-llm/multi-provider-router-llm.ts
@@ -26,7 +26,12 @@ import {
   RouterLLMPolicyBypassError,
   RouterLLMProviderError,
 } from './errors';
-import { recordLlmCall, recordLlmError, recordLlmCircuitBreakerBlock } from '../../observability/metrics';
+import {
+  recordLlmCall,
+  recordLlmError,
+  recordLlmCircuitBreakerBlock,
+  type RoutingMetricAttributes,
+} from '../../observability/metrics';
 import { dumpRawRouterResponse } from './raw-response-dump';
 import { ProviderCircuitBreaker } from './circuit-breaker';
 import type {
@@ -147,6 +152,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
 
     // Determine which providers are enabled
     const enabledProviders: Array<{ client: ProviderClient; model: string; name: RouterLLMProvider }> = [];
+    const metricAttributes = this.toRoutingMetricAttributes(context.requestMetadata);
 
     if (this.config.openai.enabled && this.openaiClient) {
       enabledProviders.push({
@@ -186,7 +192,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
           circuitBreakerState: decision.state,
           healthState: this.healthStateFromCircuitBreaker(decision.state),
         });
-        recordLlmCircuitBreakerBlock(provider.name, {});
+        recordLlmCircuitBreakerBlock(provider.name, metricAttributes);
         continue;
       }
       invocableProviders.push(provider);
@@ -212,7 +218,14 @@ export class MultiProviderRouterLLM implements RouterLLM {
     const startTime = Date.now();
     const results = await Promise.allSettled(
       invocableProviders.map(provider =>
-        this.invokeProvider(provider.client, provider.model, provider.name, routingPrompt, eligibleModels)
+        this.invokeProvider(
+          provider.client,
+          provider.model,
+          provider.name,
+          routingPrompt,
+          eligibleModels,
+          metricAttributes
+        )
       )
     );
     const totalLatencyMs = Date.now() - startTime;
@@ -363,9 +376,10 @@ export class MultiProviderRouterLLM implements RouterLLM {
   private async invokeProvider(
     client: ProviderClient,
     model: string,
-    providerName: string,
+    providerName: RouterLLMProvider,
     routingPrompt: string,
-    eligibleModels: string[]
+    eligibleModels: string[],
+    metricAttributes: RoutingMetricAttributes
   ): Promise<RankedRouteDecision> {
     let lastError: Error | undefined;
 
@@ -394,7 +408,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
           outputTokens: response.metadata.outputTokens,
           finishReason: response.metadata.finishReason,
         });
-        recordLlmCall(providerName, response.metadata.latencyMs, {});
+        recordLlmCall(providerName, response.metadata.latencyMs, metricAttributes);
 
         // Parse response as JSON
         let parsed: any;
@@ -442,7 +456,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
         return rankedDecision;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
-        recordLlmError(providerName, {});
+        recordLlmError(providerName, metricAttributes);
 
         // Don't retry on certain error types
         if (
@@ -618,5 +632,23 @@ export class MultiProviderRouterLLM implements RouterLLM {
       lastError: nextLastError,
       updatedAt: now,
     });
+  }
+
+  private toRoutingMetricAttributes(requestMetadata?: Record<string, unknown>): RoutingMetricAttributes {
+    if (!requestMetadata) {
+      return {};
+    }
+
+    const attributes: RoutingMetricAttributes = {};
+    if (typeof requestMetadata.token_tier === 'string') {
+      attributes.token_tier = requestMetadata.token_tier;
+    }
+    if (typeof requestMetadata.router_model_requested === 'string') {
+      attributes.router_model_requested = requestMetadata.router_model_requested;
+    }
+    if (typeof requestMetadata.router_model_used === 'string') {
+      attributes.router_model_used = requestMetadata.router_model_used;
+    }
+    return attributes;
   }
 }

--- a/src/routing/router-llm/multi-provider-router-llm.ts
+++ b/src/routing/router-llm/multi-provider-router-llm.ts
@@ -16,7 +16,7 @@ import type { RouterLLM } from '../engine';
 import type { TokenConfig, RankedRouteDecision, RankedModel, ProviderRanking } from '../../types/index';
 import type { ProviderClient } from './providers/types';
 import { OpenAIClient, GeminiClient } from './providers/index';
-import { loadRouterLLMConfig, type RouterLLMConfig } from '../config';
+import { loadRouterLLMConfig, type RouterLLMConfig, type RouterLLMProvider } from '../config';
 import { buildRoutingPrompt } from './prompt-builder';
 import { validateRankedRouteDecision } from '../ranked-routing';
 import {
@@ -29,6 +29,12 @@ import {
 import { recordLlmCall, recordLlmError } from '../../observability/metrics';
 import { dumpRawRouterResponse } from './raw-response-dump';
 import { ProviderCircuitBreaker } from './circuit-breaker';
+import type {
+  RouterProviderHealthStore,
+  ProviderHealthState,
+  PreflightStatus,
+  CircuitBreakerState,
+} from './provider-health';
 
 /**
  * Result from querying all router LLM providers
@@ -56,6 +62,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
   private readonly geminiClient?: ProviderClient;
   private readonly logger?: Console;
   private readonly circuitBreaker: ProviderCircuitBreaker;
+  private readonly providerHealthStore?: RouterProviderHealthStore;
 
   /**
    * Creates a new MultiProviderRouterLLM instance
@@ -63,7 +70,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
    * @param config - Optional configuration (defaults to loading from environment)
    * @param logger - Optional logger (defaults to console)
    */
-  constructor(config?: RouterLLMConfig, logger?: Console) {
+  constructor(config?: RouterLLMConfig, logger?: Console, providerHealthStore?: RouterProviderHealthStore) {
     this.config = config ?? loadRouterLLMConfig();
     this.circuitBreaker = new ProviderCircuitBreaker({
       errorThreshold: this.config.reliability.circuitBreakerErrorThreshold,
@@ -80,6 +87,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
     }
 
     this.logger = logger;
+    this.providerHealthStore = providerHealthStore;
   }
 
   /**
@@ -138,7 +146,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
     });
 
     // Determine which providers are enabled
-    const enabledProviders: Array<{ client: ProviderClient; model: string; name: string }> = [];
+    const enabledProviders: Array<{ client: ProviderClient; model: string; name: RouterLLMProvider }> = [];
 
     if (this.config.openai.enabled && this.openaiClient) {
       enabledProviders.push({
@@ -164,7 +172,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
       );
     }
 
-    const invocableProviders: Array<{ client: ProviderClient; model: string; name: string }> = [];
+    const invocableProviders: Array<{ client: ProviderClient; model: string; name: RouterLLMProvider }> = [];
     const breakerBlockedProviders: Array<{ name: string; model: string; state: string }> = [];
     for (const provider of enabledProviders) {
       const decision = this.circuitBreaker.shouldAllowRequest(provider.name, provider.model);
@@ -173,6 +181,11 @@ export class MultiProviderRouterLLM implements RouterLLM {
           name: provider.name,
           model: provider.model,
           state: decision.state,
+        });
+        this.updateProviderHealth(provider.name, provider.model, {
+          circuitBreakerState: decision.state,
+          healthState: this.healthStateFromCircuitBreaker(decision.state),
+          lastError: `Provider blocked by circuit breaker (${decision.state})`,
         });
         continue;
       }
@@ -216,12 +229,27 @@ export class MultiProviderRouterLLM implements RouterLLM {
 
       if (result.status === 'fulfilled') {
         this.circuitBreaker.recordSuccess(provider.name, provider.model);
+        this.updateProviderHealth(provider.name, provider.model, {
+          circuitBreakerState: this.circuitBreaker.getState(provider.name, provider.model),
+          healthState: 'healthy',
+          consecutiveFailures: 0,
+          lastSuccessAt: new Date().toISOString(),
+          lastError: undefined,
+        });
         decisions.push(result.value);
       } else {
         this.circuitBreaker.recordFailure(provider.name, provider.model);
+        const circuitBreakerState = this.circuitBreaker.getState(provider.name, provider.model);
         failedProviders.push({
           name: provider.name,
           error: result.reason instanceof Error ? result.reason : new Error(String(result.reason)),
+        });
+        this.updateProviderHealth(provider.name, provider.model, {
+          circuitBreakerState,
+          healthState: this.healthStateFromCircuitBreaker(circuitBreakerState),
+          consecutiveFailuresIncrement: 1,
+          lastFailureAt: new Date().toISOString(),
+          lastError: result.reason instanceof Error ? result.reason.message : String(result.reason),
         });
       }
     });
@@ -265,7 +293,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
     // Get list of successful providers for logging
     const successfulProviders = results
       .map((result, index) => result.status === 'fulfilled' ? invocableProviders[index] : null)
-      .filter((p): p is { client: ProviderClient; model: string; name: string } => p !== null);
+      .filter((p): p is { client: ProviderClient; model: string; name: RouterLLMProvider } => p !== null);
 
     // If only one provider succeeded, use its decision as consensus
     if (decisions.length === 1) {
@@ -539,5 +567,56 @@ export class MultiProviderRouterLLM implements RouterLLM {
    */
   getConfig(): RouterLLMConfig {
     return { ...this.config };
+  }
+
+  private healthStateFromCircuitBreaker(state: CircuitBreakerState): ProviderHealthState {
+    if (state === 'open') {
+      return 'unhealthy';
+    }
+    if (state === 'half_open') {
+      return 'degraded';
+    }
+    return 'healthy';
+  }
+
+  private updateProviderHealth(
+    provider: RouterLLMProvider,
+    model: string,
+    update: {
+      circuitBreakerState: CircuitBreakerState;
+      healthState: ProviderHealthState;
+      consecutiveFailures?: number;
+      consecutiveFailuresIncrement?: number;
+      lastSuccessAt?: string;
+      lastFailureAt?: string;
+      lastError?: string;
+      preflightStatus?: PreflightStatus;
+    }
+  ): void {
+    if (!this.providerHealthStore) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const existing = this.providerHealthStore.get(provider, model);
+    const existingConsecutiveFailures = existing?.consecutiveFailures ?? 0;
+    const resolvedConsecutiveFailures = update.consecutiveFailures ?? (
+      existingConsecutiveFailures + (update.consecutiveFailuresIncrement ?? 0)
+    );
+    const hasLastError = Object.prototype.hasOwnProperty.call(update, 'lastError');
+    const nextLastError = hasLastError ? update.lastError : existing?.lastError;
+
+    this.providerHealthStore.set({
+      provider,
+      model,
+      healthState: update.healthState,
+      circuitBreakerState: update.circuitBreakerState,
+      preflightStatus: update.preflightStatus ?? existing?.preflightStatus ?? 'unknown',
+      consecutiveFailures: resolvedConsecutiveFailures,
+      lastSuccessAt: update.lastSuccessAt ?? existing?.lastSuccessAt,
+      lastFailureAt: update.lastFailureAt ?? existing?.lastFailureAt,
+      lastError: nextLastError,
+      updatedAt: now,
+    });
   }
 }

--- a/src/routing/router-llm/multi-provider-router-llm.ts
+++ b/src/routing/router-llm/multi-provider-router-llm.ts
@@ -28,6 +28,7 @@ import {
 } from './errors';
 import { recordLlmCall, recordLlmError } from '../../observability/metrics';
 import { dumpRawRouterResponse } from './raw-response-dump';
+import { ProviderCircuitBreaker } from './circuit-breaker';
 
 /**
  * Result from querying all router LLM providers
@@ -54,6 +55,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
   private readonly openaiClient?: ProviderClient;
   private readonly geminiClient?: ProviderClient;
   private readonly logger?: Console;
+  private readonly circuitBreaker: ProviderCircuitBreaker;
 
   /**
    * Creates a new MultiProviderRouterLLM instance
@@ -63,6 +65,11 @@ export class MultiProviderRouterLLM implements RouterLLM {
    */
   constructor(config?: RouterLLMConfig, logger?: Console) {
     this.config = config ?? loadRouterLLMConfig();
+    this.circuitBreaker = new ProviderCircuitBreaker({
+      errorThreshold: this.config.reliability.circuitBreakerErrorThreshold,
+      windowMs: this.config.reliability.circuitBreakerWindowMs,
+      openMs: this.config.reliability.circuitBreakerOpenMs,
+    });
 
     // Only initialize clients for enabled providers
     if (this.config.openai.enabled && this.config.openai.apiKey) {
@@ -157,10 +164,33 @@ export class MultiProviderRouterLLM implements RouterLLM {
       );
     }
 
+    const invocableProviders: Array<{ client: ProviderClient; model: string; name: string }> = [];
+    const breakerBlockedProviders: Array<{ name: string; model: string; state: string }> = [];
+    for (const provider of enabledProviders) {
+      const decision = this.circuitBreaker.shouldAllowRequest(provider.name, provider.model);
+      if (!decision.allowed) {
+        breakerBlockedProviders.push({
+          name: provider.name,
+          model: provider.model,
+          state: decision.state,
+        });
+        continue;
+      }
+      invocableProviders.push(provider);
+    }
+
+    if (invocableProviders.length === 0) {
+      throw new RouterLLMError(
+        `All router LLM providers blocked by circuit breaker: ` +
+        `${breakerBlockedProviders.map((p) => `${p.name}(${p.state})`).join(', ')}`
+      );
+    }
+
     // Log invocation
-    const providerNames = enabledProviders.map(p => p.name).join(' + ');
+    const providerNames = invocableProviders.map(p => p.name).join(' + ');
     this.logger?.log(`[MultiProviderRouterLLM] Invoking ${providerNames}`, {
-      providers: enabledProviders.map(p => ({ name: p.name, model: p.model })),
+      providers: invocableProviders.map(p => ({ name: p.name, model: p.model })),
+      blockedByCircuitBreaker: breakerBlockedProviders,
       eligibleModels,
       preferModel: context.preferModel,
     });
@@ -168,7 +198,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
     // Invoke all enabled providers in parallel using Promise.allSettled for resilience
     const startTime = Date.now();
     const results = await Promise.allSettled(
-      enabledProviders.map(provider =>
+      invocableProviders.map(provider =>
         this.invokeProvider(provider.client, provider.model, provider.name, routingPrompt, eligibleModels)
       )
     );
@@ -179,14 +209,16 @@ export class MultiProviderRouterLLM implements RouterLLM {
     const failedProviders: Array<{ name: string; error: Error }> = [];
 
     results.forEach((result, index) => {
-      const provider = enabledProviders[index];
+      const provider = invocableProviders[index];
       if (!provider) {
         return;
       }
 
       if (result.status === 'fulfilled') {
+        this.circuitBreaker.recordSuccess(provider.name, provider.model);
         decisions.push(result.value);
       } else {
+        this.circuitBreaker.recordFailure(provider.name, provider.model);
         failedProviders.push({
           name: provider.name,
           error: result.reason instanceof Error ? result.reason : new Error(String(result.reason)),
@@ -218,7 +250,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
 
     // Map decisions to their provider names
     results.forEach((result, index) => {
-      const provider = enabledProviders[index];
+      const provider = invocableProviders[index];
       if (!provider || result.status !== 'fulfilled') {
         return;
       }
@@ -232,7 +264,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
 
     // Get list of successful providers for logging
     const successfulProviders = results
-      .map((result, index) => result.status === 'fulfilled' ? enabledProviders[index] : null)
+      .map((result, index) => result.status === 'fulfilled' ? invocableProviders[index] : null)
       .filter((p): p is { client: ProviderClient; model: string; name: string } => p !== null);
 
     // If only one provider succeeded, use its decision as consensus

--- a/test/routing/circuit-breaker.test.ts
+++ b/test/routing/circuit-breaker.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { ProviderCircuitBreaker } from '../../src/routing/router-llm/circuit-breaker';
+
+describe('ProviderCircuitBreaker', () => {
+  it('starts closed and allows requests', () => {
+    const breaker = new ProviderCircuitBreaker({
+      errorThreshold: 2,
+      windowMs: 1000,
+      openMs: 500,
+    });
+
+    const decision = breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 1000);
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.state).toBe('closed');
+    expect(breaker.getState('openai', 'gpt-4o-mini', 1000)).toBe('closed');
+  });
+
+  it('opens after threshold failures within the window', () => {
+    const breaker = new ProviderCircuitBreaker({
+      errorThreshold: 2,
+      windowMs: 1000,
+      openMs: 500,
+    });
+
+    breaker.recordFailure('openai', 'gpt-4o-mini', 1000);
+    breaker.recordFailure('openai', 'gpt-4o-mini', 1200);
+
+    expect(breaker.getState('openai', 'gpt-4o-mini', 1200)).toBe('open');
+    const blocked = breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 1300);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.state).toBe('open');
+  });
+
+  it('enters half-open after open window and allows only one probe', () => {
+    const breaker = new ProviderCircuitBreaker({
+      errorThreshold: 1,
+      windowMs: 1000,
+      openMs: 500,
+    });
+
+    breaker.recordFailure('gemini', 'gemini-2.5-flash', 1000);
+    expect(breaker.getState('gemini', 'gemini-2.5-flash', 1200)).toBe('open');
+
+    const firstProbe = breaker.shouldAllowRequest('gemini', 'gemini-2.5-flash', 1500);
+    expect(firstProbe.allowed).toBe(true);
+    expect(firstProbe.state).toBe('half_open');
+
+    const secondProbe = breaker.shouldAllowRequest('gemini', 'gemini-2.5-flash', 1501);
+    expect(secondProbe.allowed).toBe(false);
+    expect(secondProbe.state).toBe('half_open');
+  });
+
+  it('closes after half-open success', () => {
+    const breaker = new ProviderCircuitBreaker({
+      errorThreshold: 1,
+      windowMs: 1000,
+      openMs: 500,
+    });
+
+    breaker.recordFailure('openai', 'gpt-4o-mini', 1000);
+    breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 1500); // half-open probe
+    breaker.recordSuccess('openai', 'gpt-4o-mini', 1501);
+
+    expect(breaker.getState('openai', 'gpt-4o-mini', 1501)).toBe('closed');
+    const allowed = breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 1502);
+    expect(allowed.allowed).toBe(true);
+    expect(allowed.state).toBe('closed');
+  });
+
+  it('re-opens after half-open probe failure', () => {
+    const breaker = new ProviderCircuitBreaker({
+      errorThreshold: 1,
+      windowMs: 1000,
+      openMs: 500,
+    });
+
+    breaker.recordFailure('openai', 'gpt-4o-mini', 1000);
+    breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 1500); // half-open probe
+    breaker.recordFailure('openai', 'gpt-4o-mini', 1501);
+
+    expect(breaker.getState('openai', 'gpt-4o-mini', 1502)).toBe('open');
+    const blocked = breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 1502);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.state).toBe('open');
+  });
+
+  it('prunes failures outside the sliding window', () => {
+    const breaker = new ProviderCircuitBreaker({
+      errorThreshold: 2,
+      windowMs: 1000,
+      openMs: 500,
+    });
+
+    breaker.recordFailure('gemini', 'gemini-2.5-flash', 1000);
+    breaker.recordFailure('gemini', 'gemini-2.5-flash', 2501);
+
+    expect(breaker.getState('gemini', 'gemini-2.5-flash', 2501)).toBe('closed');
+    const allowed = breaker.shouldAllowRequest('gemini', 'gemini-2.5-flash', 2501);
+    expect(allowed.allowed).toBe(true);
+    expect(allowed.state).toBe('closed');
+  });
+});
+

--- a/test/routing/circuit-breaker.test.ts
+++ b/test/routing/circuit-breaker.test.ts
@@ -100,5 +100,33 @@ describe('ProviderCircuitBreaker', () => {
     expect(allowed.allowed).toBe(true);
     expect(allowed.state).toBe('closed');
   });
-});
 
+  it('handles full cycle: closed -> open -> half_open fail -> open -> half_open success -> closed', () => {
+    const breaker = new ProviderCircuitBreaker({
+      errorThreshold: 1,
+      windowMs: 1000,
+      openMs: 500,
+    });
+
+    // closed -> open
+    breaker.recordFailure('openai', 'gpt-4o-mini', 1000);
+    expect(breaker.getState('openai', 'gpt-4o-mini', 1001)).toBe('open');
+
+    // open -> half_open probe, then failed probe re-opens
+    const probeOne = breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 1500);
+    expect(probeOne.allowed).toBe(true);
+    expect(probeOne.state).toBe('half_open');
+    breaker.recordFailure('openai', 'gpt-4o-mini', 1501);
+    expect(breaker.getState('openai', 'gpt-4o-mini', 1502)).toBe('open');
+
+    // open -> half_open probe, then success closes
+    const probeTwo = breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 2001);
+    expect(probeTwo.allowed).toBe(true);
+    expect(probeTwo.state).toBe('half_open');
+    breaker.recordSuccess('openai', 'gpt-4o-mini', 2002);
+
+    const finalDecision = breaker.shouldAllowRequest('openai', 'gpt-4o-mini', 2003);
+    expect(finalDecision.allowed).toBe(true);
+    expect(finalDecision.state).toBe('closed');
+  });
+});

--- a/test/routing/multi-provider-router-llm.test.ts
+++ b/test/routing/multi-provider-router-llm.test.ts
@@ -205,7 +205,15 @@ describe('MultiProviderRouterLLM circuit breaker integration', () => {
     const geminiHealth = healthStore.get('gemini', 'gemini-2.5-flash');
     expect(openaiHealth?.circuitBreakerState).toBe('open');
     expect(openaiHealth?.healthState).toBe('unhealthy');
+    expect(openaiHealth?.lastError).toContain('openai down');
     expect(geminiHealth?.circuitBreakerState).toBe('closed');
     expect(geminiHealth?.healthState).toBe('healthy');
+    const originalLastError = openaiHealth?.lastError;
+
+    // On blocked follow-up requests, keep the original root-cause error message.
+    await router.invoke('second', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig });
+    const openaiBlockedHealth = healthStore.get('openai', 'gpt-4o-mini');
+    expect(openaiBlockedHealth?.circuitBreakerState).toBe('open');
+    expect(openaiBlockedHealth?.lastError).toBe(originalLastError);
   });
 });

--- a/test/routing/multi-provider-router-llm.test.ts
+++ b/test/routing/multi-provider-router-llm.test.ts
@@ -3,6 +3,7 @@ import type { RouterLLMConfig } from '../../src/routing/config';
 import { MultiProviderRouterLLM } from '../../src/routing/router-llm/multi-provider-router-llm';
 import type { ProviderClient } from '../../src/routing/router-llm/providers/types';
 import type { TokenConfig } from '../../src/types';
+import { InMemoryRouterProviderHealthStore } from '../../src/routing/router-llm/provider-health';
 
 const tokenConfig: TokenConfig = {
   id: 'token-1',
@@ -58,9 +59,10 @@ function providerResponse(model: string, provider: string): ReturnType<ProviderC
 function createRouterWithClients(
   openaiClient: ProviderClient,
   geminiClient: ProviderClient,
-  config: RouterLLMConfig = baseConfig
+  config: RouterLLMConfig = baseConfig,
+  providerHealthStore?: InMemoryRouterProviderHealthStore
 ): MultiProviderRouterLLM {
-  const router = new MultiProviderRouterLLM(config);
+  const router = new MultiProviderRouterLLM(config, undefined, providerHealthStore);
   const mutableRouter = router as unknown as {
     openaiClient: ProviderClient;
     geminiClient: ProviderClient;
@@ -108,7 +110,6 @@ describe('MultiProviderRouterLLM circuit breaker integration', () => {
 
     const openaiInvoke = vi.fn()
       .mockRejectedValueOnce(new Error('openai unavailable'))
-      .mockResolvedValue(providerResponse('gpt-4o-mini', 'openai'))
       .mockResolvedValue(providerResponse('gpt-4o-mini', 'openai'));
     const geminiInvoke = vi.fn().mockResolvedValue(providerResponse('gemini-2.5-flash', 'gemini'));
 
@@ -154,5 +155,57 @@ describe('MultiProviderRouterLLM circuit breaker integration', () => {
     expect(alwaysFailOpenAI).toHaveBeenCalledTimes(1);
     expect(alwaysFailGemini).toHaveBeenCalledTimes(1);
   });
-});
 
+  it('fails fast for single-provider configuration after breaker opens', async () => {
+    const config: RouterLLMConfig = {
+      ...baseConfig,
+      gemini: {
+        ...baseConfig.gemini,
+        enabled: false,
+      },
+      reliability: {
+        ...baseConfig.reliability,
+        circuitBreakerErrorThreshold: 1,
+      },
+    };
+    const alwaysFailOpenAI = vi.fn().mockRejectedValue(new Error('openai down'));
+
+    const router = createRouterWithClients(
+      { invoke: alwaysFailOpenAI, getProviderName: () => 'openai' },
+      { invoke: vi.fn(), getProviderName: () => 'gemini' },
+      config
+    );
+
+    await expect(
+      router.invoke('first', ['gpt-4o-mini'], { tokenConfig })
+    ).rejects.toThrow('All router LLM providers failed');
+    expect(alwaysFailOpenAI).toHaveBeenCalledTimes(1);
+
+    await expect(
+      router.invoke('second', ['gpt-4o-mini'], { tokenConfig })
+    ).rejects.toThrow('blocked by circuit breaker');
+    expect(alwaysFailOpenAI).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes circuit-breaker state updates into provider health store', async () => {
+    const healthStore = new InMemoryRouterProviderHealthStore();
+    const alwaysFailOpenAI = vi.fn().mockRejectedValue(new Error('openai down'));
+    const geminiInvoke = vi.fn().mockResolvedValue(providerResponse('gemini-2.5-flash', 'gemini'));
+
+    const router = createRouterWithClients(
+      { invoke: alwaysFailOpenAI, getProviderName: () => 'openai' },
+      { invoke: geminiInvoke, getProviderName: () => 'gemini' },
+      baseConfig,
+      healthStore
+    );
+
+    await router.invoke('first', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig });
+
+    const openaiHealth = healthStore.get('openai', 'gpt-4o-mini');
+    const geminiHealth = healthStore.get('gemini', 'gemini-2.5-flash');
+    expect(openaiHealth?.circuitBreakerState).toBe('open');
+    expect(openaiHealth?.healthState).toBe('unhealthy');
+    expect(geminiHealth?.circuitBreakerState).toBe('closed');
+    expect(geminiHealth?.healthState).toBe('healthy');
+  });
+});

--- a/test/routing/multi-provider-router-llm.test.ts
+++ b/test/routing/multi-provider-router-llm.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { RouterLLMConfig } from '../../src/routing/config';
+import { MultiProviderRouterLLM } from '../../src/routing/router-llm/multi-provider-router-llm';
+import type { ProviderClient } from '../../src/routing/router-llm/providers/types';
+import type { TokenConfig } from '../../src/types';
+
+const tokenConfig: TokenConfig = {
+  id: 'token-1',
+  token_hash: 'hash-1',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const baseConfig: RouterLLMConfig = {
+  openai: {
+    enabled: true,
+    apiKey: 'openai-test-key',
+    model: 'gpt-4o-mini',
+  },
+  gemini: {
+    enabled: true,
+    apiKey: 'gemini-test-key',
+    model: 'gemini-2.5-flash',
+  },
+  timeout: 5000,
+  maxRetries: 0,
+  temperature: 0,
+  maxTokens: 400,
+  reliability: {
+    preflightMode: 'warn',
+    preflightTimeoutMs: 1000,
+    circuitBreakerWindowMs: 60_000,
+    circuitBreakerErrorThreshold: 1,
+    circuitBreakerOpenMs: 50,
+    consensusMode: 'full',
+  },
+};
+
+function providerResponse(model: string, provider: string): ReturnType<ProviderClient['invoke']> {
+  return Promise.resolve({
+    content: JSON.stringify({
+      intent: 'test intent',
+      ranked_models: [
+        { rank: 1, model: 'gpt-4o-mini', score: 9, reason: 'good fit' },
+        { rank: 2, model: 'gemini-2.5-flash', score: 8, reason: 'fallback fit' },
+      ],
+    }),
+    metadata: {
+      model,
+      provider,
+      latencyMs: 12,
+      inputTokens: 10,
+      outputTokens: 20,
+    },
+  });
+}
+
+function createRouterWithClients(
+  openaiClient: ProviderClient,
+  geminiClient: ProviderClient,
+  config: RouterLLMConfig = baseConfig
+): MultiProviderRouterLLM {
+  const router = new MultiProviderRouterLLM(config);
+  const mutableRouter = router as unknown as {
+    openaiClient: ProviderClient;
+    geminiClient: ProviderClient;
+  };
+  mutableRouter.openaiClient = openaiClient;
+  mutableRouter.geminiClient = geminiClient;
+  return router;
+}
+
+describe('MultiProviderRouterLLM circuit breaker integration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('opens the breaker on provider failure and falls back to remaining provider', async () => {
+    const openaiInvoke = vi.fn()
+      .mockRejectedValueOnce(new Error('openai unavailable'))
+      .mockResolvedValue(providerResponse('gpt-4o-mini', 'openai'));
+    const geminiInvoke = vi.fn().mockResolvedValue(providerResponse('gemini-2.5-flash', 'gemini'));
+
+    const router = createRouterWithClients(
+      { invoke: openaiInvoke, getProviderName: () => 'openai' },
+      { invoke: geminiInvoke, getProviderName: () => 'gemini' }
+    );
+
+    const first = await router.invoke('route this prompt', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig }) as {
+      provider_rankings: Record<string, unknown>;
+    };
+    expect(first.provider_rankings.gemini).toBeDefined();
+    expect(openaiInvoke).toHaveBeenCalledTimes(1);
+    expect(geminiInvoke).toHaveBeenCalledTimes(1);
+
+    const second = await router.invoke('route this prompt again', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig }) as {
+      provider_rankings: Record<string, unknown>;
+    };
+    expect(second.provider_rankings.gemini).toBeDefined();
+    expect(openaiInvoke).toHaveBeenCalledTimes(1);
+    expect(geminiInvoke).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows a half-open probe after open timeout and closes on success', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const openaiInvoke = vi.fn()
+      .mockRejectedValueOnce(new Error('openai unavailable'))
+      .mockResolvedValue(providerResponse('gpt-4o-mini', 'openai'))
+      .mockResolvedValue(providerResponse('gpt-4o-mini', 'openai'));
+    const geminiInvoke = vi.fn().mockResolvedValue(providerResponse('gemini-2.5-flash', 'gemini'));
+
+    const router = createRouterWithClients(
+      { invoke: openaiInvoke, getProviderName: () => 'openai' },
+      { invoke: geminiInvoke, getProviderName: () => 'gemini' }
+    );
+
+    await router.invoke('first', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig });
+    await router.invoke('second', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig });
+    expect(openaiInvoke).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(51);
+
+    const third = await router.invoke('third', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig }) as {
+      provider_rankings: Record<string, unknown>;
+    };
+    expect(third.provider_rankings.openai).toBeDefined();
+    expect(openaiInvoke).toHaveBeenCalledTimes(2);
+
+    await router.invoke('fourth', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig });
+    expect(openaiInvoke).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails fast when every provider is open', async () => {
+    const alwaysFailOpenAI = vi.fn().mockRejectedValue(new Error('openai down'));
+    const alwaysFailGemini = vi.fn().mockRejectedValue(new Error('gemini down'));
+
+    const router = createRouterWithClients(
+      { invoke: alwaysFailOpenAI, getProviderName: () => 'openai' },
+      { invoke: alwaysFailGemini, getProviderName: () => 'gemini' }
+    );
+
+    await expect(
+      router.invoke('first', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig })
+    ).rejects.toThrow('All router LLM providers failed');
+    expect(alwaysFailOpenAI).toHaveBeenCalledTimes(1);
+    expect(alwaysFailGemini).toHaveBeenCalledTimes(1);
+
+    await expect(
+      router.invoke('second', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig })
+    ).rejects.toThrow('blocked by circuit breaker');
+    expect(alwaysFailOpenAI).toHaveBeenCalledTimes(1);
+    expect(alwaysFailGemini).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add provider/model circuit breaker state machine with sliding-window failures and half-open probing
- integrate breaker gating into multi-provider routing so open providers are skipped and healthy providers continue to serve traffic
- fail fast when all enabled providers are breaker-blocked
- add unit coverage for breaker transitions and multi-provider fallback/recovery behavior

## Testing
- npm run build
- npm test -- test/routing/circuit-breaker.test.ts test/routing/multi-provider-router-llm.test.ts
- npm test -- test/routing/config.test.ts test/routing/providers.test.ts