### PR TITLE
Add router startup preflight policy

### DIFF
--- a/docs/design/TODO.md
+++ b/docs/design/TODO.md
@@ -145,7 +145,7 @@
   - Add `closed/open/half_open` gating in multi-provider invocation path.
   - Add state-transition tests and failure-recovery tests.
   - Gate: integration tests show fallback without hammering broken providers.
-- [ ] **PR4: Startup preflight + startup policy**
+- [x] **PR4: Startup preflight + startup policy**
   - Add startup preflight service and apply mode semantics (`strict|warn|off`).
   - Persist and expose preflight status in provider health state.
   - Add startup tests for fail/pass behavior by mode.

--- a/src/app.ts
+++ b/src/app.ts
@@ -466,6 +466,9 @@ export async function createApp(deps?: Partial<AppDependencies>): Promise<{
         const preflight = new RouterStartupPreflight(config, routerProviderHealthStore, logger);
         const summary = await preflight.run();
 
+        // Strict mode enforces minimum availability (at least one healthy provider).
+        // It intentionally allows startup with partial failures so traffic can continue
+        // on healthy providers while degraded provider(s) are repaired.
         if (summary.passCount === 0) {
           const message =
             'Router startup preflight found no healthy providers. ' +
@@ -485,14 +488,14 @@ export async function createApp(deps?: Partial<AppDependencies>): Promise<{
             fail_count: summary.failCount,
             providers: summary.results,
           });
+        } else {
+          logger.info('Router startup preflight completed', {
+            mode: config.reliability.preflightMode,
+            pass_count: summary.passCount,
+            fail_count: summary.failCount,
+            providers: summary.results,
+          });
         }
-
-        logger.info('Router startup preflight completed', {
-          mode: config.reliability.preflightMode,
-          pass_count: summary.passCount,
-          fail_count: summary.failCount,
-          providers: summary.results,
-        });
       } else if (enabledProviders.length > 0) {
         logger.info('Router startup preflight disabled', {
           mode: config.reliability.preflightMode,

--- a/src/app.ts
+++ b/src/app.ts
@@ -33,7 +33,17 @@ import {
   ModelRegistrySyncService,
   ModelValidationError,
 } from './models';
-import { createRoutingEngine, createRoutingRoutes, RoutingEngine, StubRouterLLM, MultiProviderRouterLLM } from './routing';
+import {
+  createRoutingEngine,
+  createRoutingRoutes,
+  RoutingEngine,
+  StubRouterLLM,
+  MultiProviderRouterLLM,
+  RouterStartupPreflight,
+  RouterStartupPreflightError,
+  InMemoryRouterProviderHealthStore,
+  type RouterProviderHealthStore,
+} from './routing';
 import { createFeedbackHandler, createFeedbackRoutes, FeedbackHandler } from './feedback';
 import { createOpinionPoller, OpinionPoller } from './polling';
 import { createLogger, Logger } from './logging';
@@ -72,6 +82,7 @@ export interface AppDependencies {
   knowledgeStore: KnowledgeStore;
   modelRegistry: DefaultModelRegistry;
   modelRegistrySyncService?: ModelRegistrySyncService;
+  routerProviderHealthStore?: RouterProviderHealthStore;
   routingEngine: RoutingEngine;
   feedbackHandler: FeedbackHandler;
   opinionPoller: OpinionPoller;
@@ -432,15 +443,16 @@ export async function createApp(deps?: Partial<AppDependencies>): Promise<{
   const knowledgeStore = deps?.knowledgeStore ?? createKnowledgeStore(redis, modelRegistry);
   const opinionPoller = deps?.opinionPoller ?? createOpinionPoller(knowledgeStore, modelRegistry);
   const feedbackHandler = deps?.feedbackHandler ?? createFeedbackHandler(knowledgeStore);
+  const routerProviderHealthStore = deps?.routerProviderHealthStore ?? new InMemoryRouterProviderHealthStore();
 
   // Initialize router LLM (REQUIRED for production, optional for test/dev)
   // Note: loadRouterLLMConfig() (called by MultiProviderRouterLLM constructor) validates
   // that at least one provider is enabled in production mode, so no need for redundant checks here
   let routerLLM;
   try {
-    routerLLM = new MultiProviderRouterLLM(undefined, console);
+    routerLLM = new MultiProviderRouterLLM(undefined, console, routerProviderHealthStore);
     const config = routerLLM.getConfig();
-    const enabledProviders = [];
+    const enabledProviders: string[] = [];
     if (config.openai.enabled) enabledProviders.push('OpenAI');
     if (config.gemini.enabled) enabledProviders.push('Gemini');
 
@@ -450,9 +462,47 @@ export async function createApp(deps?: Partial<AppDependencies>): Promise<{
       });
       routerLLM = new StubRouterLLM();
     } else {
+      if (enabledProviders.length > 0 && config.reliability.preflightMode !== 'off') {
+        const preflight = new RouterStartupPreflight(config, routerProviderHealthStore, logger);
+        const summary = await preflight.run();
+
+        if (summary.passCount === 0) {
+          const message =
+            'Router startup preflight found no healthy providers. ' +
+            `mode=${config.reliability.preflightMode}, failed=${summary.failCount}`;
+          if (config.reliability.preflightMode === 'strict') {
+            throw new RouterStartupPreflightError(message, summary);
+          }
+
+          logger.warn(message, {
+            mode: config.reliability.preflightMode,
+            summary,
+          });
+        } else {
+          logger.info('Router startup preflight completed', {
+            mode: config.reliability.preflightMode,
+            pass_count: summary.passCount,
+            fail_count: summary.failCount,
+            providers: summary.results,
+          });
+        }
+      } else if (enabledProviders.length > 0) {
+        logger.info('Router startup preflight disabled', {
+          mode: config.reliability.preflightMode,
+        });
+      }
+
       logger.info(`Router LLM initialized with providers: ${enabledProviders.join(' + ')}`);
     }
   } catch (error) {
+    if (error instanceof RouterStartupPreflightError) {
+      logger.error('Router startup preflight failed', {
+        error: error.message,
+        summary: error.summary,
+      });
+      throw error;
+    }
+
     const errorMsg = error instanceof Error ? error.message : String(error);
 
     // In production, router LLM initialization failure is fatal
@@ -495,6 +545,7 @@ export async function createApp(deps?: Partial<AppDependencies>): Promise<{
     knowledgeStore,
     modelRegistry,
     modelRegistrySyncService,
+    routerProviderHealthStore,
     routingEngine,
     feedbackHandler,
     opinionPoller,

--- a/src/app.ts
+++ b/src/app.ts
@@ -478,14 +478,21 @@ export async function createApp(deps?: Partial<AppDependencies>): Promise<{
             mode: config.reliability.preflightMode,
             summary,
           });
-        } else {
-          logger.info('Router startup preflight completed', {
+        } else if (summary.failCount > 0) {
+          logger.warn('Router startup preflight completed with partial failures', {
             mode: config.reliability.preflightMode,
             pass_count: summary.passCount,
             fail_count: summary.failCount,
             providers: summary.results,
           });
         }
+
+        logger.info('Router startup preflight completed', {
+          mode: config.reliability.preflightMode,
+          pass_count: summary.passCount,
+          fail_count: summary.failCount,
+          providers: summary.results,
+        });
       } else if (enabledProviders.length > 0) {
         logger.info('Router startup preflight disabled', {
           mode: config.reliability.preflightMode,

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -28,4 +28,8 @@ export {
   loadRouterLLMConfig,
   type RouterLLMConfig,
   type RouterLLMProvider,
+  RouterStartupPreflight,
+  RouterStartupPreflightError,
+  InMemoryRouterProviderHealthStore,
+  type RouterProviderHealthStore,
 } from './router-llm/index';

--- a/src/routing/router-llm/index.ts
+++ b/src/routing/router-llm/index.ts
@@ -27,6 +27,12 @@ export {
 export { buildRoutingPrompt } from './prompt-builder';
 export { parseRouteDecision, parseRouteDecisionLenient, extractJSON } from './response-parser';
 export {
+  RouterStartupPreflight,
+  RouterStartupPreflightError,
+  type RouterPreflightProviderResult,
+  type RouterPreflightSummary,
+} from './preflight';
+export {
   ProviderCircuitBreaker,
   type CircuitBreakerConfig,
   type CircuitBreakerDecision,

--- a/src/routing/router-llm/preflight.ts
+++ b/src/routing/router-llm/preflight.ts
@@ -36,36 +36,43 @@ export class RouterStartupPreflight {
   ) {}
 
   async run(): Promise<RouterPreflightSummary> {
-    const probes = this.getEnabledProviderConfigs();
-    const results: RouterPreflightProviderResult[] = [];
+    const probes = this.getConfiguredProviderProbes();
+    const results = await Promise.all(
+      probes.map(async (probe): Promise<RouterPreflightProviderResult> => {
+        const startedAt = Date.now();
+        if (!probe.apiKey) {
+          return {
+            provider: probe.provider,
+            model: probe.model,
+            status: 'fail',
+            latencyMs: Date.now() - startedAt,
+            error: `${probe.provider} is enabled but API key is missing`,
+          };
+        }
 
-    for (const probe of probes) {
-      const startedAt = Date.now();
-      try {
-        const client = this.clientFactory(probe.provider, probe.apiKey);
-        await this.invokeProbe(client, probe.provider, probe.model);
+        try {
+          const client = this.clientFactory(probe.provider, probe.apiKey);
+          await this.invokeProbe(client, probe.provider, probe.model);
+          return {
+            provider: probe.provider,
+            model: probe.model,
+            status: 'pass',
+            latencyMs: Date.now() - startedAt,
+          };
+        } catch (error) {
+          return {
+            provider: probe.provider,
+            model: probe.model,
+            status: 'fail',
+            latencyMs: Date.now() - startedAt,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      })
+    );
 
-        const latencyMs = Date.now() - startedAt;
-        const result: RouterPreflightProviderResult = {
-          provider: probe.provider,
-          model: probe.model,
-          status: 'pass',
-          latencyMs,
-        };
-        this.updateHealth(result);
-        results.push(result);
-      } catch (error) {
-        const latencyMs = Date.now() - startedAt;
-        const result: RouterPreflightProviderResult = {
-          provider: probe.provider,
-          model: probe.model,
-          status: 'fail',
-          latencyMs,
-          error: error instanceof Error ? error.message : String(error),
-        };
-        this.updateHealth(result);
-        results.push(result);
-      }
+    for (const result of results) {
+      this.updateHealth(result);
     }
 
     const passCount = results.filter((result) => result.status === 'pass').length;
@@ -119,23 +126,33 @@ export class RouterStartupPreflight {
     ) {
       throw new Error(`${provider} preflight returned invalid routing payload`);
     }
+
+    const firstRankedModel = (parsed as { ranked_models: unknown[] }).ranked_models[0];
+    if (
+      typeof firstRankedModel !== 'object' ||
+      firstRankedModel === null ||
+      typeof (firstRankedModel as { model?: unknown }).model !== 'string' ||
+      (firstRankedModel as { model: string }).model.trim().length === 0
+    ) {
+      throw new Error(`${provider} preflight returned ranked_models without a valid model id`);
+    }
   }
 
-  private getEnabledProviderConfigs(): Array<{
+  private getConfiguredProviderProbes(): Array<{
     provider: RouterLLMProvider;
     model: string;
-    apiKey: string;
+    apiKey?: string;
   }> {
-    const providers: Array<{ provider: RouterLLMProvider; model: string; apiKey: string }> = [];
+    const providers: Array<{ provider: RouterLLMProvider; model: string; apiKey?: string }> = [];
 
-    if (this.config.openai.enabled && this.config.openai.apiKey) {
+    if (this.config.openai.enabled) {
       providers.push({
         provider: 'openai',
         model: this.config.openai.model,
         apiKey: this.config.openai.apiKey,
       });
     }
-    if (this.config.gemini.enabled && this.config.gemini.apiKey) {
+    if (this.config.gemini.enabled) {
       providers.push({
         provider: 'gemini',
         model: this.config.gemini.model,
@@ -146,22 +163,19 @@ export class RouterStartupPreflight {
     return providers;
   }
 
-  private healthStateForResult(result: RouterPreflightProviderResult): ProviderHealthState {
-    return result.status === 'pass' ? 'healthy' : 'unhealthy';
-  }
-
   private updateHealth(result: RouterPreflightProviderResult): void {
     const existing = this.healthStore.get(result.provider, result.model);
     const now = new Date().toISOString();
     const circuitBreakerState: CircuitBreakerState = existing?.circuitBreakerState ?? 'closed';
+    const existingFailures = existing?.consecutiveFailures ?? 0;
 
     this.healthStore.set({
       provider: result.provider,
       model: result.model,
-      healthState: this.healthStateForResult(result),
+      healthState: (result.status === 'pass' ? 'healthy' : 'unhealthy') as ProviderHealthState,
       circuitBreakerState,
       preflightStatus: result.status,
-      consecutiveFailures: existing?.consecutiveFailures ?? 0,
+      consecutiveFailures: result.status === 'fail' ? existingFailures + 1 : 0,
       lastSuccessAt: result.status === 'pass' ? now : existing?.lastSuccessAt,
       lastFailureAt: result.status === 'fail' ? now : existing?.lastFailureAt,
       lastError: result.status === 'fail' ? result.error : existing?.lastError,

--- a/src/routing/router-llm/preflight.ts
+++ b/src/routing/router-llm/preflight.ts
@@ -178,7 +178,7 @@ export class RouterStartupPreflight {
       consecutiveFailures: result.status === 'fail' ? existingFailures + 1 : 0,
       lastSuccessAt: result.status === 'pass' ? now : existing?.lastSuccessAt,
       lastFailureAt: result.status === 'fail' ? now : existing?.lastFailureAt,
-      lastError: result.status === 'fail' ? result.error : existing?.lastError,
+      lastError: result.status === 'fail' ? result.error : undefined,
       updatedAt: now,
     });
 

--- a/src/routing/router-llm/preflight.ts
+++ b/src/routing/router-llm/preflight.ts
@@ -1,0 +1,186 @@
+import type { RouterLLMConfig, RouterLLMProvider } from '../config';
+import { createProviderClient } from './providers';
+import type { ProviderClient } from './providers/types';
+import type { RouterProviderHealthStore, ProviderHealthState, CircuitBreakerState } from './provider-health';
+import type { Logger } from '../../logging/logger';
+
+export interface RouterPreflightProviderResult {
+  provider: RouterLLMProvider;
+  model: string;
+  status: 'pass' | 'fail';
+  latencyMs: number;
+  error?: string;
+}
+
+export interface RouterPreflightSummary {
+  results: RouterPreflightProviderResult[];
+  passCount: number;
+  failCount: number;
+}
+
+export class RouterStartupPreflightError extends Error {
+  constructor(message: string, public readonly summary: RouterPreflightSummary) {
+    super(message);
+    this.name = 'RouterStartupPreflightError';
+  }
+}
+
+type ProviderClientFactory = (provider: RouterLLMProvider, apiKey: string) => ProviderClient;
+
+export class RouterStartupPreflight {
+  constructor(
+    private readonly config: RouterLLMConfig,
+    private readonly healthStore: RouterProviderHealthStore,
+    private readonly logger?: Pick<Logger, 'info' | 'warn'>,
+    private readonly clientFactory: ProviderClientFactory = createProviderClient
+  ) {}
+
+  async run(): Promise<RouterPreflightSummary> {
+    const probes = this.getEnabledProviderConfigs();
+    const results: RouterPreflightProviderResult[] = [];
+
+    for (const probe of probes) {
+      const startedAt = Date.now();
+      try {
+        const client = this.clientFactory(probe.provider, probe.apiKey);
+        await this.invokeProbe(client, probe.provider, probe.model);
+
+        const latencyMs = Date.now() - startedAt;
+        const result: RouterPreflightProviderResult = {
+          provider: probe.provider,
+          model: probe.model,
+          status: 'pass',
+          latencyMs,
+        };
+        this.updateHealth(result);
+        results.push(result);
+      } catch (error) {
+        const latencyMs = Date.now() - startedAt;
+        const result: RouterPreflightProviderResult = {
+          provider: probe.provider,
+          model: probe.model,
+          status: 'fail',
+          latencyMs,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        this.updateHealth(result);
+        results.push(result);
+      }
+    }
+
+    const passCount = results.filter((result) => result.status === 'pass').length;
+    const failCount = results.length - passCount;
+    return { results, passCount, failCount };
+  }
+
+  private async invokeProbe(
+    client: ProviderClient,
+    provider: RouterLLMProvider,
+    model: string
+  ): Promise<void> {
+    const probePayload = {
+      intent: 'startup_preflight',
+      ranked_models: [
+        {
+          rank: 1,
+          model,
+          score: 10,
+          reason: 'startup preflight probe',
+        },
+      ],
+    };
+
+    const response = await client.invoke({
+      prompt:
+        'Return only valid JSON matching this exact structure (no markdown):\n' +
+        `${JSON.stringify(probePayload)}`,
+      model,
+      temperature: 0,
+      maxTokens: 256,
+      timeout: this.config.reliability.preflightTimeoutMs,
+    });
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(response.content);
+    } catch (error) {
+      throw new Error(
+        `${provider} preflight returned non-JSON response: ` +
+        `${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('ranked_models' in parsed) ||
+      !Array.isArray((parsed as { ranked_models: unknown[] }).ranked_models) ||
+      (parsed as { ranked_models: unknown[] }).ranked_models.length === 0
+    ) {
+      throw new Error(`${provider} preflight returned invalid routing payload`);
+    }
+  }
+
+  private getEnabledProviderConfigs(): Array<{
+    provider: RouterLLMProvider;
+    model: string;
+    apiKey: string;
+  }> {
+    const providers: Array<{ provider: RouterLLMProvider; model: string; apiKey: string }> = [];
+
+    if (this.config.openai.enabled && this.config.openai.apiKey) {
+      providers.push({
+        provider: 'openai',
+        model: this.config.openai.model,
+        apiKey: this.config.openai.apiKey,
+      });
+    }
+    if (this.config.gemini.enabled && this.config.gemini.apiKey) {
+      providers.push({
+        provider: 'gemini',
+        model: this.config.gemini.model,
+        apiKey: this.config.gemini.apiKey,
+      });
+    }
+
+    return providers;
+  }
+
+  private healthStateForResult(result: RouterPreflightProviderResult): ProviderHealthState {
+    return result.status === 'pass' ? 'healthy' : 'unhealthy';
+  }
+
+  private updateHealth(result: RouterPreflightProviderResult): void {
+    const existing = this.healthStore.get(result.provider, result.model);
+    const now = new Date().toISOString();
+    const circuitBreakerState: CircuitBreakerState = existing?.circuitBreakerState ?? 'closed';
+
+    this.healthStore.set({
+      provider: result.provider,
+      model: result.model,
+      healthState: this.healthStateForResult(result),
+      circuitBreakerState,
+      preflightStatus: result.status,
+      consecutiveFailures: existing?.consecutiveFailures ?? 0,
+      lastSuccessAt: result.status === 'pass' ? now : existing?.lastSuccessAt,
+      lastFailureAt: result.status === 'fail' ? now : existing?.lastFailureAt,
+      lastError: result.status === 'fail' ? result.error : existing?.lastError,
+      updatedAt: now,
+    });
+
+    if (result.status === 'pass') {
+      this.logger?.info('Router provider preflight passed', {
+        provider: result.provider,
+        model: result.model,
+        latency_ms: result.latencyMs,
+      });
+    } else {
+      this.logger?.warn('Router provider preflight failed', {
+        provider: result.provider,
+        model: result.model,
+        latency_ms: result.latencyMs,
+        error: result.error,
+      });
+    }
+  }
+}

--- a/test/routing/preflight-startup.test.ts
+++ b/test/routing/preflight-startup.test.ts
@@ -53,6 +53,18 @@ function openAiFailureResponse() {
   };
 }
 
+function geminiFailureResponse() {
+  return {
+    ok: false,
+    status: 500,
+    json: async () => ({
+      error: {
+        message: 'gemini unavailable',
+      },
+    }),
+  };
+}
+
 describe('Router startup preflight policy', () => {
   const originalEnv = { ...process.env };
   const originalFetch = global.fetch;
@@ -85,8 +97,9 @@ describe('Router startup preflight policy', () => {
 
     const result = await createApp({ redis: new Redis() });
 
-    const preflightStatus = result.dependencies.routerProviderHealthStore?.get('openai', 'gpt-4o-mini')?.preflightStatus;
-    expect(preflightStatus).toBe('fail');
+    const snapshot = result.dependencies.routerProviderHealthStore?.get('openai', 'gpt-4o-mini');
+    expect(snapshot?.preflightStatus).toBe('fail');
+    expect(snapshot?.consecutiveFailures).toBe(1);
   });
 
   it('skips startup probes when preflight mode is off', async () => {
@@ -108,5 +121,34 @@ describe('Router startup preflight policy', () => {
     expect(snapshot?.preflightStatus).toBe('pass');
     expect(snapshot?.healthState).toBe('healthy');
   });
-});
 
+  it('records partial preflight failures when one provider passes and one fails', async () => {
+    process.env.ROUTER_PREFLIGHT_MODE = 'warn';
+    process.env.ROUTER_LLM_GEMINI_ENABLED = 'true';
+    process.env.ROUTER_LLM_GEMINI_API_KEY = 'test-gemini-key';
+
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('openai.com')) {
+        return Promise.resolve(openAiSuccessResponse() as Response);
+      }
+      return Promise.resolve(geminiFailureResponse() as Response);
+    });
+
+    const result = await createApp({ redis: new Redis() });
+
+    const openai = result.dependencies.routerProviderHealthStore?.get('openai', 'gpt-4o-mini');
+    const gemini = result.dependencies.routerProviderHealthStore?.get('gemini', 'gemini-1.5-flash');
+    expect(openai?.preflightStatus).toBe('pass');
+    expect(gemini?.preflightStatus).toBe('fail');
+    expect(gemini?.consecutiveFailures).toBe(1);
+  });
+
+  it('treats enabled provider without API key as failed preflight', async () => {
+    process.env.ROUTER_PREFLIGHT_MODE = 'strict';
+    delete process.env.ROUTER_LLM_OPENAI_API_KEY;
+    global.fetch = vi.fn();
+
+    await expect(createApp({ redis: new Redis() })).rejects.toBeInstanceOf(RouterStartupPreflightError);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/routing/preflight-startup.test.ts
+++ b/test/routing/preflight-startup.test.ts
@@ -143,6 +143,26 @@ describe('Router startup preflight policy', () => {
     expect(gemini?.consecutiveFailures).toBe(1);
   });
 
+  it('allows startup in strict mode when at least one provider passes', async () => {
+    process.env.ROUTER_PREFLIGHT_MODE = 'strict';
+    process.env.ROUTER_LLM_GEMINI_ENABLED = 'true';
+    process.env.ROUTER_LLM_GEMINI_API_KEY = 'test-gemini-key';
+
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('openai.com')) {
+        return Promise.resolve(openAiSuccessResponse() as Response);
+      }
+      return Promise.resolve(geminiFailureResponse() as Response);
+    });
+
+    const result = await createApp({ redis: new Redis() });
+
+    const openai = result.dependencies.routerProviderHealthStore?.get('openai', 'gpt-4o-mini');
+    const gemini = result.dependencies.routerProviderHealthStore?.get('gemini', 'gemini-1.5-flash');
+    expect(openai?.preflightStatus).toBe('pass');
+    expect(gemini?.preflightStatus).toBe('fail');
+  });
+
   it('treats enabled provider without API key as failed preflight', async () => {
     process.env.ROUTER_PREFLIGHT_MODE = 'strict';
     delete process.env.ROUTER_LLM_OPENAI_API_KEY;

--- a/test/routing/preflight-startup.test.ts
+++ b/test/routing/preflight-startup.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Redis from 'ioredis-mock';
+import { createApp } from '../../src/app';
+import { RouterStartupPreflightError } from '../../src/routing';
+
+function openAiSuccessResponse() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      id: 'chatcmpl-preflight',
+      object: 'chat.completion',
+      created: Date.now(),
+      model: 'gpt-4o-mini',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: JSON.stringify({
+              intent: 'startup_preflight',
+              ranked_models: [
+                {
+                  rank: 1,
+                  model: 'gpt-4o-mini',
+                  score: 10,
+                  reason: 'preflight',
+                },
+              ],
+            }),
+          },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 10,
+        total_tokens: 20,
+      },
+    }),
+  };
+}
+
+function openAiFailureResponse() {
+  return {
+    ok: false,
+    status: 500,
+    json: async () => ({
+      error: {
+        message: 'provider unavailable',
+      },
+    }),
+  };
+}
+
+describe('Router startup preflight policy', () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ROUTER_LLM_OPENAI_ENABLED = 'true';
+    process.env.ROUTER_LLM_OPENAI_API_KEY = 'test-openai-key';
+    process.env.ROUTER_LLM_GEMINI_ENABLED = 'false';
+    process.env.LANGCACHE_ENABLED = 'false';
+    process.env.FEATURE_USER_SELF_SERVICE = 'false';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('blocks startup in strict mode when all preflight probes fail', async () => {
+    process.env.ROUTER_PREFLIGHT_MODE = 'strict';
+    global.fetch = vi.fn().mockResolvedValue(openAiFailureResponse() as Response);
+
+    await expect(createApp({ redis: new Redis() })).rejects.toBeInstanceOf(RouterStartupPreflightError);
+  });
+
+  it('allows startup in warn mode when preflight probes fail', async () => {
+    process.env.ROUTER_PREFLIGHT_MODE = 'warn';
+    global.fetch = vi.fn().mockResolvedValue(openAiFailureResponse() as Response);
+
+    const result = await createApp({ redis: new Redis() });
+
+    const preflightStatus = result.dependencies.routerProviderHealthStore?.get('openai', 'gpt-4o-mini')?.preflightStatus;
+    expect(preflightStatus).toBe('fail');
+  });
+
+  it('skips startup probes when preflight mode is off', async () => {
+    process.env.ROUTER_PREFLIGHT_MODE = 'off';
+    global.fetch = vi.fn().mockResolvedValue(openAiSuccessResponse() as Response);
+
+    await createApp({ redis: new Redis() });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('records pass preflight status on successful probe', async () => {
+    process.env.ROUTER_PREFLIGHT_MODE = 'warn';
+    global.fetch = vi.fn().mockResolvedValue(openAiSuccessResponse() as Response);
+
+    const result = await createApp({ redis: new Redis() });
+
+    const snapshot = result.dependencies.routerProviderHealthStore?.get('openai', 'gpt-4o-mini');
+    expect(snapshot?.preflightStatus).toBe('pass');
+    expect(snapshot?.healthState).toBe('healthy');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add router startup preflight service that probes each enabled provider and model at boot
- enforce startup policy via ROUTER_PREFLIGHT_MODE modes strict, warn, and off
- persist provider preflight pass or fail status into router provider health store snapshots
- wire health store and preflight runner into createApp router initialization
- add startup tests covering strict failure, warn continuation, off skip, and pass status persistence

## Testing
- npm run build
- npm test -- test/routing/preflight-startup.test.ts test/routing/config.test.ts
- npm test -- test/routing/multi-provider-router-llm.test.ts test/routing/circuit-breaker.test.ts