### PR TITLE
PR6: Fast consensus mode and router rollout runbook

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -60,7 +60,16 @@ Typical fields:
 - `redis_connected`
 - `langcache_enabled`
 - `langcache_connected`
+- `router_provider_configured_count`
+- `router_provider_snapshot_count`
+- `router_provider_healthy_count`
+- `router_provider_unhealthy_count`
 - optional LangCache last error/success timestamps
+
+Admin-authenticated diagnostics:
+- Send `X-Admin-Api-Key` to include sensitive diagnostics in response:
+  - `router_provider_health` (per-provider snapshot detail)
+  - Redis/LangCache last error diagnostics
 
 ### GET /llm-spec
 Machine-readable integration spec for LLM/coding assistants.
@@ -159,6 +168,30 @@ Deprecated endpoint; returns `410`.
 
 #### GET /admin/models
 Returns full model list, count, and default model id.
+
+### Router Diagnostics
+
+#### GET /admin/router/providers
+Returns per-provider router health snapshots:
+- `provider`, `model`
+- `health_state`, `circuit_breaker_state`, `preflight_status`
+- `consecutive_failures`
+- `last_success_at`, `last_failure_at`, `last_error`
+- `updated_at`
+
+#### POST /admin/router/validate
+Runs live provider preflight probes (incurs provider API calls/cost).
+
+Response:
+- `mode`
+- `summary` (`results`, `passCount`, `failCount`)
+- `note`
+- `timestamp`
+
+Status behavior:
+- `200` at least one provider passed
+- `503` no providers passed
+- `429` validation cooldown active (`retry_after_ms` included)
 
 ### Model Registry
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,19 @@ At least one provider must be enabled. Both can be enabled for multi-provider ra
 | `ROUTER_LLM_TEMPERATURE` | Sampling temperature (0.0-2.0) | `0.0` |
 | `ROUTER_LLM_MAX_TOKENS` | Maximum tokens in LLM response | `2000` |
 
+#### Router Reliability and Consensus
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ROUTER_PREFLIGHT_MODE` | Startup/provider-validation mode: `strict`, `warn`, or `off` | `strict` in production, `warn` otherwise |
+| `ROUTER_PREFLIGHT_TIMEOUT_MS` | Per-provider probe timeout for startup/admin validation | `10000` |
+| `ROUTER_CIRCUIT_BREAKER_ERROR_THRESHOLD` | Failures in window before opening breaker | `3` |
+| `ROUTER_CIRCUIT_BREAKER_WINDOW_MS` | Sliding failure window duration | `60000` |
+| `ROUTER_CIRCUIT_BREAKER_OPEN_MS` | Time breaker remains open before half-open probe | `30000` |
+| `ROUTER_CONSENSUS_MODE` | `full` waits for all successful providers; `fast` returns first success and continues async telemetry | `full` |
+| `ROUTER_COMPAT_RETRY_ENABLED` | Enable one-shot provider compatibility retries (`true`/`false`) | `true` |
+| `ROUTER_VALIDATE_MIN_INTERVAL_MS` | Minimum interval between `POST /admin/router/validate` calls on a single instance | `30000` |
+
 #### Model Registry Provider Sync (Optional, Recommended)
 
 Use provider catalog sync to keep the system registry current. Sync can run at startup and/or on-demand via `POST /admin/registry/refresh`.
@@ -372,4 +385,3 @@ If you see `RouterLLMError` or `ROUTER_LLM_API_KEY` error, check:
 1. API key is set in `.env`
 2. API key is valid for your provider
 3. API key has sufficient quota
-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,11 @@ At least one provider must be enabled. Both can be enabled for multi-provider ra
 | `ROUTER_COMPAT_RETRY_ENABLED` | Enable one-shot provider compatibility retries (`true`/`false`) | `true` |
 | `ROUTER_VALIDATE_MIN_INTERVAL_MS` | Minimum interval between `POST /admin/router/validate` calls on a single instance | `30000` |
 
+Notes:
+- In `ROUTER_CONSENSUS_MODE=fast`, Wayfinder returns the first successful provider result and lets other provider calls continue in the background for health/telemetry updates.
+- Background calls still follow `ROUTER_LLM_MAX_RETRIES`; if you want to minimize background API spend in `fast` mode, consider setting `ROUTER_LLM_MAX_RETRIES=0`.
+- If only one provider is invocable at runtime (for example, another provider is disabled or circuit-breaker blocked), fast mode falls back to the standard single-provider flow.
+
 #### Model Registry Provider Sync (Optional, Recommended)
 
 Use provider catalog sync to keep the system registry current. Sync can run at startup and/or on-demand via `POST /admin/registry/refresh`.

--- a/docs/design/TODO.md
+++ b/docs/design/TODO.md
@@ -150,7 +150,7 @@
   - Persist and expose preflight status in provider health state.
   - Add startup tests for fail/pass behavior by mode.
   - Gate: strict mode blocks startup when all providers are unhealthy.
-- [ ] **PR5: Health/admin diagnostics + observability**
+- [x] **PR5: Health/admin diagnostics + observability**
   - Extend `/health` with router provider/model summary.
   - Add admin endpoints: `GET /admin/router/providers`, `POST /admin/router/validate`.
   - Add metrics/events for compatibility retries, breaker transitions, preflight outcomes.
@@ -160,6 +160,7 @@
   - Add `ROUTER_CONSENSUS_MODE=fast` runtime path with async secondary telemetry.
   - Add benchmarks and guardrails for latency-sensitive routes.
   - Gate: documented release playbook and target latency validation in staging.
+  - Status: runbook + fast mode implemented; latency benchmark harness still pending.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 - `docs/quick-start.md` - Quick start and local development setup.
 - `docs/core-concepts.md` - Routing, policy, cache, and model concepts.
 - `docs/configuration.md` - Environment and runtime configuration.
+- `docs/observability/router-rollout-runbook.md` - Router model rollout and validate-before-promote runbook.
 - `docs/examples.md` - Curl examples and end-to-end usage examples.
 - `docs/architecture.md` - Architecture and project structure.
 - `docs/troubleshooting.md` - Operational and local troubleshooting.

--- a/docs/observability/router-rollout-runbook.md
+++ b/docs/observability/router-rollout-runbook.md
@@ -1,0 +1,66 @@
+# Router Model Rollout Runbook
+
+Use this runbook when changing router provider models or reliability settings.
+
+## Goals
+- Prevent request-shape regressions when switching router models.
+- Validate provider health before serving production traffic.
+- Control latency/cost tradeoffs with `ROUTER_CONSENSUS_MODE`.
+
+## Pre-Change Checklist
+- Confirm at least one provider key is valid for the target environment.
+- Confirm `ROUTER_PREFLIGHT_MODE` is set:
+  - `strict` in production (recommended)
+  - `warn` in lower environments for diagnosis
+- Confirm admin access is available for `POST /admin/router/validate`.
+
+## Rollout Procedure (Validate Before Promote)
+1. Deploy config/model changes to staging.
+2. Run:
+   - `POST /admin/router/validate`
+3. Verify result:
+   - `summary.passCount >= 1`
+   - inspect failed providers and error messages if `failCount > 0`
+4. Verify health diagnostics:
+   - `GET /health` with `X-Admin-Api-Key`
+   - ensure `router_provider_health` entries are healthy/expected
+5. Exercise synthetic route traffic in staging (sample prompts).
+6. Promote to production only after staging validation passes.
+7. Immediately run production validation:
+   - `POST /admin/router/validate`
+8. Monitor 15-30 minutes:
+   - router errors
+   - circuit breaker transitions/blocks
+   - preflight outcomes
+   - latency and cache-hit behavior
+
+## Consensus Mode Guidance
+
+### `ROUTER_CONSENSUS_MODE=full`
+- Waits for all successful providers and aggregates rankings.
+- Best for quality consistency.
+- Higher latency.
+
+### `ROUTER_CONSENSUS_MODE=fast`
+- Returns first successful provider result.
+- Keeps other provider calls running asynchronously for health/telemetry updates.
+- Best for latency-sensitive paths.
+- Tradeoff: fewer provider rankings in immediate response.
+
+## Latency Guardrails
+- Start with `full` in production unless latency SLO requires `fast`.
+- Use `fast` when uncached route latency is above SLO and provider quality is acceptable.
+- Re-validate after switching modes:
+  - P50/P95 latency
+  - routing error rate
+  - fallback/circuit-breaker behavior
+
+## Safe Rollback
+- Revert environment variables to previous known-good values.
+- Re-deploy.
+- Re-run `POST /admin/router/validate`.
+- Confirm `/health` provider snapshot recovery.
+
+## Notes
+- `POST /admin/router/validate` performs live provider calls and can incur API cost.
+- Validation cooldown may return `429` if called repeatedly in short intervals.

--- a/docs/observability/router-rollout-runbook.md
+++ b/docs/observability/router-rollout-runbook.md
@@ -46,6 +46,9 @@ Use this runbook when changing router provider models or reliability settings.
 - Keeps other provider calls running asynchronously for health/telemetry updates.
 - Best for latency-sensitive paths.
 - Tradeoff: fewer provider rankings in immediate response.
+- Explicit provider routing (`router_model=openai|gemini`) is preserved; Wayfinder waits for the requested provider result when that provider is invocable.
+- Background calls still apply `ROUTER_LLM_MAX_RETRIES`; for tighter cost control in fast mode, consider `ROUTER_LLM_MAX_RETRIES=0`.
+- If only one provider is invocable (for example breaker-open on the other provider), fast mode falls back to single-provider standard flow.
 
 ## Latency Guardrails
 - Start with `full` in production unless latency SLO requires `fast`.

--- a/src/routing/engine.ts
+++ b/src/routing/engine.ts
@@ -420,7 +420,10 @@ export class DefaultRoutingEngine implements RoutingEngine {
     const rawDecision = await this.deps.routerLLM.invoke(request.prompt, eligibleModels, {
       tokenConfig: effectiveTokenConfig,
       preferModel: request.prefer_model,
-      requestMetadata: request.metadata,
+      requestMetadata: {
+        ...(request.metadata ?? {}),
+        router_model_requested: effectiveRouter,
+      },
       userLLMKeys, // Pass user's LLM keys if BYOLLM tier
       eligibleModelRegistry,
     });

--- a/src/routing/engine.ts
+++ b/src/routing/engine.ts
@@ -19,6 +19,7 @@ import type { Logger } from '../logging/logger';
 import type { SemanticCache } from '../cache';
 import { hashPrompt } from '../cache';
 import type { MultiProviderResult } from './router-llm';
+import { ROUTER_MODEL_REQUESTED_METADATA_KEY } from './router-llm';
 import { isDefaultToken, resolveEligibleModels, selectDefaultEligibleModelIds } from '../tokens/utils';
 import type { DefaultTokenProfileStore } from '../tokens/default-profile-store';
 import { recordCacheHit, recordCacheMiss } from '../observability/metrics';
@@ -422,7 +423,7 @@ export class DefaultRoutingEngine implements RoutingEngine {
       preferModel: request.prefer_model,
       requestMetadata: {
         ...(request.metadata ?? {}),
-        router_model_requested: effectiveRouter,
+        [ROUTER_MODEL_REQUESTED_METADATA_KEY]: effectiveRouter,
       },
       userLLMKeys, // Pass user's LLM keys if BYOLLM tier
       eligibleModelRegistry,

--- a/src/routing/router-llm/index.ts
+++ b/src/routing/router-llm/index.ts
@@ -5,7 +5,11 @@
  */
 
 export { DefaultRouterLLM } from './default-router-llm';
-export { MultiProviderRouterLLM, type MultiProviderResult } from './multi-provider-router-llm';
+export {
+  MultiProviderRouterLLM,
+  type MultiProviderResult,
+  ROUTER_MODEL_REQUESTED_METADATA_KEY,
+} from './multi-provider-router-llm';
 export { BYOLLMRouterLLM } from './byollm-router-llm';
 export { StubRouterLLM } from './stub-router-llm';
 export { buildProviderInvocationPlan, type ProviderInvocationPlan } from './provider-adapter';

--- a/src/routing/router-llm/multi-provider-router-llm.ts
+++ b/src/routing/router-llm/multi-provider-router-llm.ts
@@ -57,6 +57,11 @@ export interface MultiProviderResult {
 }
 
 /**
+ * Request metadata key used by routing engine to indicate explicitly requested router provider.
+ */
+export const ROUTER_MODEL_REQUESTED_METADATA_KEY = 'router_model_requested';
+
+/**
  * Multi-Provider Router LLM implementation
  *
  * Queries both OpenAI and Gemini, then averages their rankings to produce
@@ -69,7 +74,6 @@ export class MultiProviderRouterLLM implements RouterLLM {
   private readonly logger?: Console;
   private readonly circuitBreaker: ProviderCircuitBreaker;
   private readonly providerHealthStore?: RouterProviderHealthStore;
-  private readonly providerOrder: ReadonlyArray<RouterLLMProvider> = ['openai', 'gemini'];
 
   /**
    * Creates a new MultiProviderRouterLLM instance
@@ -233,7 +237,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
         metricAttributes,
         requestedProvider
       );
-    } else if (this.config.reliability.consensusMode === 'fast' && invocableProviders.length <= 1) {
+    } else if (this.config.reliability.consensusMode === 'fast' && invocableProviders.length === 1) {
       this.logger?.log('[MultiProviderRouterLLM] Fast consensus fallback to standard flow (single invocable provider)', {
         invocable_count: invocableProviders.length,
       });
@@ -407,7 +411,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
     routingPrompt: string,
     eligibleModels: string[],
     metricAttributes: RoutingMetricAttributes,
-    requestedProvider?: RouterLLMProvider
+    requestedProvider?: string
   ): Promise<MultiProviderResult> {
     const startTime = Date.now();
     const failedProviders: Array<{ name: string; error: Error }> = [];
@@ -463,14 +467,18 @@ export class MultiProviderRouterLLM implements RouterLLM {
         throw error;
       }
     });
-    const providersByName = new Map(invocableProviders.map((provider, index) => [provider.name, providerTasks[index]]));
+    const providersByName = new Map(
+      invocableProviders.map((provider, index) => [provider.name, providerTasks[index]])
+    );
 
     let firstSuccess: {
       provider: { client: ProviderClient; model: string; name: RouterLLMProvider };
       decision: RankedRouteDecision;
     };
     try {
-      const requestedTask = requestedProvider ? providersByName.get(requestedProvider) : undefined;
+      const requestedTask = requestedProvider
+        ? providersByName.get(requestedProvider as RouterLLMProvider)
+        : undefined;
       if (requestedTask) {
         try {
           firstSuccess = await requestedTask;
@@ -481,10 +489,27 @@ export class MultiProviderRouterLLM implements RouterLLM {
         firstSuccess = await Promise.any(providerTasks);
       }
     } catch (error) {
-      const errorMessages = failedProviders.map((failed) => `${failed.name}: ${failed.error.message}`).join('; ');
-      const fallbackError = failedProviders[0]?.error ?? (
-        error instanceof Error ? error : new Error('All router LLM providers failed')
-      );
+      // Promise.any rejects with AggregateError after all tasks have rejected.
+      // Re-collect from settled tasks so error reporting is complete and deterministic.
+      const settledResults = await Promise.allSettled(providerTasks);
+      const allFailures = settledResults
+        .map((settled, index) => ({ settled, provider: invocableProviders[index] }))
+        .filter((item): item is {
+          settled: PromiseRejectedResult;
+          provider: { client: ProviderClient; model: string; name: RouterLLMProvider };
+        } => item.provider !== undefined && item.settled.status === 'rejected')
+        .map((item) => ({
+          name: item.provider.name,
+          error: item.settled.reason instanceof Error ? item.settled.reason : new Error(String(item.settled.reason)),
+        }));
+
+      const errorMessages = allFailures.map((failed) => `${failed.name}: ${failed.error.message}`).join('; ');
+      const fallbackError = allFailures[0]?.error ??
+        (error instanceof AggregateError && error.errors.length > 0 && error.errors[0] instanceof Error
+          ? error.errors[0]
+          : error instanceof Error
+            ? error
+            : new Error('All router LLM providers failed'));
       throw new RouterLLMError(
         `All router LLM providers failed: ${errorMessages}`,
         fallbackError
@@ -518,6 +543,8 @@ export class MultiProviderRouterLLM implements RouterLLM {
     });
 
     // Keep other in-flight provider calls running for async health/telemetry updates.
+    // Note: tasks are already started and the winner has already completed; this callback only
+    // processes background rejections and does not duplicate success bookkeeping.
     void Promise.allSettled(providerTasks).then((settledResults) => {
       const backgroundFailures = settledResults
         .map((settled, index) => ({ settled, provider: invocableProviders[index] }))
@@ -543,14 +570,9 @@ export class MultiProviderRouterLLM implements RouterLLM {
     };
   }
 
-  private extractRequestedProvider(requestMetadata?: Record<string, unknown>): RouterLLMProvider | undefined {
-    const requested = requestMetadata?.router_model_requested;
-    if (typeof requested !== 'string') {
-      return undefined;
-    }
-    return this.providerOrder.includes(requested as RouterLLMProvider)
-      ? (requested as RouterLLMProvider)
-      : undefined;
+  private extractRequestedProvider(requestMetadata?: Record<string, unknown>): string | undefined {
+    const requested = requestMetadata?.[ROUTER_MODEL_REQUESTED_METADATA_KEY];
+    return typeof requested === 'string' ? requested : undefined;
   }
 
   /**

--- a/src/routing/router-llm/multi-provider-router-llm.ts
+++ b/src/routing/router-llm/multi-provider-router-llm.ts
@@ -69,6 +69,7 @@ export class MultiProviderRouterLLM implements RouterLLM {
   private readonly logger?: Console;
   private readonly circuitBreaker: ProviderCircuitBreaker;
   private readonly providerHealthStore?: RouterProviderHealthStore;
+  private readonly providerOrder: ReadonlyArray<RouterLLMProvider> = ['openai', 'gemini'];
 
   /**
    * Creates a new MultiProviderRouterLLM instance
@@ -224,12 +225,18 @@ export class MultiProviderRouterLLM implements RouterLLM {
     });
 
     if (this.config.reliability.consensusMode === 'fast' && invocableProviders.length > 1) {
+      const requestedProvider = this.extractRequestedProvider(context.requestMetadata);
       return this.invokeFastConsensus(
         invocableProviders,
         routingPrompt,
         eligibleModels,
-        metricAttributes
+        metricAttributes,
+        requestedProvider
       );
+    } else if (this.config.reliability.consensusMode === 'fast' && invocableProviders.length <= 1) {
+      this.logger?.log('[MultiProviderRouterLLM] Fast consensus fallback to standard flow (single invocable provider)', {
+        invocable_count: invocableProviders.length,
+      });
     }
 
     // Invoke all enabled providers in parallel using Promise.allSettled for resilience
@@ -399,7 +406,8 @@ export class MultiProviderRouterLLM implements RouterLLM {
     invocableProviders: Array<{ client: ProviderClient; model: string; name: RouterLLMProvider }>,
     routingPrompt: string,
     eligibleModels: string[],
-    metricAttributes: RoutingMetricAttributes
+    metricAttributes: RoutingMetricAttributes,
+    requestedProvider?: RouterLLMProvider
   ): Promise<MultiProviderResult> {
     const startTime = Date.now();
     const failedProviders: Array<{ name: string; error: Error }> = [];
@@ -455,13 +463,23 @@ export class MultiProviderRouterLLM implements RouterLLM {
         throw error;
       }
     });
+    const providersByName = new Map(invocableProviders.map((provider, index) => [provider.name, providerTasks[index]]));
 
     let firstSuccess: {
       provider: { client: ProviderClient; model: string; name: RouterLLMProvider };
       decision: RankedRouteDecision;
     };
     try {
-      firstSuccess = await Promise.any(providerTasks);
+      const requestedTask = requestedProvider ? providersByName.get(requestedProvider) : undefined;
+      if (requestedTask) {
+        try {
+          firstSuccess = await requestedTask;
+        } catch {
+          firstSuccess = await Promise.any(providerTasks);
+        }
+      } else {
+        firstSuccess = await Promise.any(providerTasks);
+      }
     } catch (error) {
       const errorMessages = failedProviders.map((failed) => `${failed.name}: ${failed.error.message}`).join('; ');
       const fallbackError = failedProviders[0]?.error ?? (
@@ -485,25 +503,54 @@ export class MultiProviderRouterLLM implements RouterLLM {
     };
 
     if (failedProviders.length > 0) {
-      this.logger?.warn('[MultiProviderRouterLLM] Fast consensus returning first success with provider failures', {
+      this.logger?.warn('[MultiProviderRouterLLM] Fast consensus observed provider failures before response', {
         failed: failedProviders.map((failed) => ({ name: failed.name, error: failed.error.message })),
+        note: 'Additional provider failures may be logged after background completion.',
       });
     }
 
     this.logger?.log('[MultiProviderRouterLLM] Fast consensus selected first successful provider', {
       provider: firstSuccess.provider.name,
+      requested_provider: requestedProvider,
       latencyMs,
       top_model: firstSuccess.decision.ranked_models[0]?.model,
       top_score: firstSuccess.decision.ranked_models[0]?.score,
     });
 
     // Keep other in-flight provider calls running for async health/telemetry updates.
-    void Promise.allSettled(providerTasks);
+    void Promise.allSettled(providerTasks).then((settledResults) => {
+      const backgroundFailures = settledResults
+        .map((settled, index) => ({ settled, provider: invocableProviders[index] }))
+        .filter((item): item is {
+          settled: PromiseRejectedResult;
+          provider: { client: ProviderClient; model: string; name: RouterLLMProvider };
+        } => item.provider !== undefined && item.settled.status === 'rejected')
+        .map((item) => ({
+          name: item.provider.name,
+          error: item.settled.reason instanceof Error ? item.settled.reason.message : String(item.settled.reason),
+        }));
+
+      if (backgroundFailures.length > 0) {
+        this.logger?.warn('[MultiProviderRouterLLM] Fast consensus background provider failures', {
+          failed: backgroundFailures,
+        });
+      }
+    });
 
     return {
       provider_rankings: providerRankings,
       consensus: firstSuccess.decision,
     };
+  }
+
+  private extractRequestedProvider(requestMetadata?: Record<string, unknown>): RouterLLMProvider | undefined {
+    const requested = requestMetadata?.router_model_requested;
+    if (typeof requested !== 'string') {
+      return undefined;
+    }
+    return this.providerOrder.includes(requested as RouterLLMProvider)
+      ? (requested as RouterLLMProvider)
+      : undefined;
   }
 
   /**

--- a/src/routing/router-llm/multi-provider-router-llm.ts
+++ b/src/routing/router-llm/multi-provider-router-llm.ts
@@ -223,6 +223,15 @@ export class MultiProviderRouterLLM implements RouterLLM {
       preferModel: context.preferModel,
     });
 
+    if (this.config.reliability.consensusMode === 'fast' && invocableProviders.length > 1) {
+      return this.invokeFastConsensus(
+        invocableProviders,
+        routingPrompt,
+        eligibleModels,
+        metricAttributes
+      );
+    }
+
     // Invoke all enabled providers in parallel using Promise.allSettled for resilience
     const startTime = Date.now();
     const results = await Promise.allSettled(
@@ -383,6 +392,117 @@ export class MultiProviderRouterLLM implements RouterLLM {
     return {
       provider_rankings: providerRankings,
       consensus: aggregatedDecision,
+    };
+  }
+
+  private async invokeFastConsensus(
+    invocableProviders: Array<{ client: ProviderClient; model: string; name: RouterLLMProvider }>,
+    routingPrompt: string,
+    eligibleModels: string[],
+    metricAttributes: RoutingMetricAttributes
+  ): Promise<MultiProviderResult> {
+    const startTime = Date.now();
+    const failedProviders: Array<{ name: string; error: Error }> = [];
+
+    const providerTasks = invocableProviders.map(async (provider) => {
+      try {
+        const decision = await this.invokeProvider(
+          provider.client,
+          provider.model,
+          provider.name,
+          routingPrompt,
+          eligibleModels,
+          metricAttributes
+        );
+
+        const previousState = this.circuitBreaker.getState(provider.name, provider.model);
+        this.circuitBreaker.recordSuccess(provider.name, provider.model);
+        const currentState = this.circuitBreaker.getState(provider.name, provider.model);
+        this.recordCircuitBreakerTransitionIfNeeded(
+          provider.name,
+          previousState,
+          currentState,
+          metricAttributes
+        );
+        this.updateProviderHealth(provider.name, provider.model, {
+          circuitBreakerState: currentState,
+          healthState: 'healthy',
+          consecutiveFailures: 0,
+          lastSuccessAt: new Date().toISOString(),
+          lastError: undefined,
+        });
+
+        return { provider, decision };
+      } catch (reason) {
+        const error = reason instanceof Error ? reason : new Error(String(reason));
+        const previousState = this.circuitBreaker.getState(provider.name, provider.model);
+        this.circuitBreaker.recordFailure(provider.name, provider.model);
+        const circuitBreakerState = this.circuitBreaker.getState(provider.name, provider.model);
+        this.recordCircuitBreakerTransitionIfNeeded(
+          provider.name,
+          previousState,
+          circuitBreakerState,
+          metricAttributes
+        );
+        this.updateProviderHealth(provider.name, provider.model, {
+          circuitBreakerState,
+          healthState: this.healthStateFromCircuitBreaker(circuitBreakerState),
+          consecutiveFailuresIncrement: 1,
+          lastFailureAt: new Date().toISOString(),
+          lastError: error.message,
+        });
+        failedProviders.push({ name: provider.name, error });
+        throw error;
+      }
+    });
+
+    let firstSuccess: {
+      provider: { client: ProviderClient; model: string; name: RouterLLMProvider };
+      decision: RankedRouteDecision;
+    };
+    try {
+      firstSuccess = await Promise.any(providerTasks);
+    } catch (error) {
+      const errorMessages = failedProviders.map((failed) => `${failed.name}: ${failed.error.message}`).join('; ');
+      const fallbackError = failedProviders[0]?.error ?? (
+        error instanceof Error ? error : new Error('All router LLM providers failed')
+      );
+      throw new RouterLLMError(
+        `All router LLM providers failed: ${errorMessages}`,
+        fallbackError
+      );
+    }
+
+    const latencyMs = Date.now() - startTime;
+    const generatedAt = new Date().toISOString();
+    const providerName = firstSuccess.provider.name as 'openai' | 'gemini';
+    const providerRankings: MultiProviderResult['provider_rankings'] = {
+      [providerName]: {
+        provider: providerName,
+        decision: firstSuccess.decision,
+        generated_at: generatedAt,
+      },
+    };
+
+    if (failedProviders.length > 0) {
+      this.logger?.warn('[MultiProviderRouterLLM] Fast consensus returning first success with provider failures', {
+        failed: failedProviders.map((failed) => ({ name: failed.name, error: failed.error.message })),
+      });
+    }
+
+    this.logger?.log('[MultiProviderRouterLLM] Fast consensus selected first successful provider', {
+      provider: firstSuccess.provider.name,
+      latencyMs,
+      top_model: firstSuccess.decision.ranked_models[0]?.model,
+      top_score: firstSuccess.decision.ranked_models[0]?.score,
+    });
+
+    // Keep other in-flight provider calls running for async health/telemetry updates.
+    void Promise.allSettled(providerTasks);
+
+    return {
+      provider_rankings: providerRankings,
+      consensus: firstSuccess.decision,
     };
   }
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -330,6 +330,20 @@ describe('API Integration Tests', () => {
       expect(typeof response.body.summary.failCount).toBe('number');
       expect(typeof response.body.note).toBe('string');
     });
+
+    it('should apply cooldown to repeated router validation calls', async () => {
+      const first = await request(app)
+        .post('/admin/router/validate')
+        .set('X-Admin-Api-Key', adminApiKey);
+      expect([200, 503]).toContain(first.status);
+
+      const second = await request(app)
+        .post('/admin/router/validate')
+        .set('X-Admin-Api-Key', adminApiKey);
+      expect(second.status).toBe(429);
+      expect(typeof second.body.retry_after_ms).toBe('number');
+      expect(typeof second.body.note).toBe('string');
+    });
   });
 
   describe('Feedback Endpoint', () => {

--- a/test/routing/multi-provider-router-llm.test.ts
+++ b/test/routing/multi-provider-router-llm.test.ts
@@ -130,6 +130,73 @@ describe('MultiProviderRouterLLM circuit breaker integration', () => {
     );
   });
 
+  it('returns first successful provider in fast consensus mode', async () => {
+    vi.useFakeTimers();
+    const fastConfig: RouterLLMConfig = {
+      ...baseConfig,
+      reliability: {
+        ...baseConfig.reliability,
+        consensusMode: 'fast',
+      },
+    };
+
+    const openaiInvoke = vi.fn().mockResolvedValue(providerResponse('gpt-4o-mini', 'openai'));
+    const geminiInvoke = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            void providerResponse('gemini-2.5-flash', 'gemini').then(resolve);
+          }, 1000);
+        })
+    );
+
+    const router = createRouterWithClients(
+      { invoke: openaiInvoke, getProviderName: () => 'openai' },
+      { invoke: geminiInvoke, getProviderName: () => 'gemini' },
+      fastConfig
+    );
+
+    const result = await router.invoke('fast route', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig }) as {
+      provider_rankings: Record<string, unknown>;
+      consensus: { ranked_models: Array<{ model: string }> };
+    };
+
+    expect(result.provider_rankings.openai).toBeDefined();
+    expect(result.provider_rankings.gemini).toBeUndefined();
+    expect(result.consensus.ranked_models[0]?.model).toBe('gpt-4o-mini');
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+  });
+
+  it('still succeeds in fast consensus mode when one provider fails', async () => {
+    const fastConfig: RouterLLMConfig = {
+      ...baseConfig,
+      reliability: {
+        ...baseConfig.reliability,
+        consensusMode: 'fast',
+      },
+    };
+    const openaiInvoke = vi.fn().mockRejectedValue(new Error('openai unavailable'));
+    const geminiInvoke = vi.fn().mockResolvedValue(providerResponse('gemini-2.5-flash', 'gemini'));
+
+    const router = createRouterWithClients(
+      { invoke: openaiInvoke, getProviderName: () => 'openai' },
+      { invoke: geminiInvoke, getProviderName: () => 'gemini' },
+      fastConfig
+    );
+
+    const result = await router.invoke('fast route fallback', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig }) as {
+      provider_rankings: Record<string, unknown>;
+    };
+
+    expect(result.provider_rankings.gemini).toBeDefined();
+    expect(metricsMocks.recordLlmCircuitBreakerTransition).toHaveBeenCalledWith(
+      'openai',
+      'closed',
+      'open',
+      {}
+    );
+  });
+
   it('allows a half-open probe after open timeout and closes on success', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));

--- a/test/routing/multi-provider-router-llm.test.ts
+++ b/test/routing/multi-provider-router-llm.test.ts
@@ -235,6 +235,36 @@ describe('MultiProviderRouterLLM circuit breaker integration', () => {
     expect(result.provider_rankings.gemini).toBeUndefined();
   });
 
+  it('falls back to another provider when explicitly requested provider fails in fast mode', async () => {
+    const fastConfig: RouterLLMConfig = {
+      ...baseConfig,
+      reliability: {
+        ...baseConfig.reliability,
+        consensusMode: 'fast',
+      },
+    };
+    const openaiInvoke = vi.fn().mockRejectedValue(new Error('openai failed'));
+    const geminiInvoke = vi.fn().mockResolvedValue(providerResponse('gemini-2.5-flash', 'gemini'));
+
+    const router = createRouterWithClients(
+      { invoke: openaiInvoke, getProviderName: () => 'openai' },
+      { invoke: geminiInvoke, getProviderName: () => 'gemini' },
+      fastConfig
+    );
+
+    const result = await router.invoke('explicit provider fallback', ['gpt-4o-mini', 'gemini-2.5-flash'], {
+      tokenConfig,
+      requestMetadata: {
+        router_model_requested: 'openai',
+      },
+    }) as {
+      provider_rankings: Record<string, unknown>;
+    };
+
+    expect(result.provider_rankings.gemini).toBeDefined();
+    expect(result.provider_rankings.openai).toBeUndefined();
+  });
+
   it('logs background provider failures after fast response is returned', async () => {
     const fastConfig: RouterLLMConfig = {
       ...baseConfig,

--- a/test/routing/multi-provider-router-llm.test.ts
+++ b/test/routing/multi-provider-router-llm.test.ts
@@ -76,9 +76,10 @@ function createRouterWithClients(
   openaiClient: ProviderClient,
   geminiClient: ProviderClient,
   config: RouterLLMConfig = baseConfig,
-  providerHealthStore?: InMemoryRouterProviderHealthStore
+  providerHealthStore?: InMemoryRouterProviderHealthStore,
+  logger?: Console
 ): MultiProviderRouterLLM {
-  const router = new MultiProviderRouterLLM(config, undefined, providerHealthStore);
+  const router = new MultiProviderRouterLLM(config, logger, providerHealthStore);
   const mutableRouter = router as unknown as {
     openaiClient: ProviderClient;
     geminiClient: ProviderClient;
@@ -194,6 +195,136 @@ describe('MultiProviderRouterLLM circuit breaker integration', () => {
       'closed',
       'open',
       {}
+    );
+  });
+
+  it('preserves explicit provider routing semantics in fast mode', async () => {
+    const fastConfig: RouterLLMConfig = {
+      ...baseConfig,
+      reliability: {
+        ...baseConfig.reliability,
+        consensusMode: 'fast',
+      },
+    };
+    const openaiInvoke = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            void providerResponse('gpt-4o-mini', 'openai').then(resolve);
+          }, 20);
+        })
+    );
+    const geminiInvoke = vi.fn().mockResolvedValue(providerResponse('gemini-2.5-flash', 'gemini'));
+
+    const router = createRouterWithClients(
+      { invoke: openaiInvoke, getProviderName: () => 'openai' },
+      { invoke: geminiInvoke, getProviderName: () => 'gemini' },
+      fastConfig
+    );
+
+    const result = await router.invoke('explicit provider request', ['gpt-4o-mini', 'gemini-2.5-flash'], {
+      tokenConfig,
+      requestMetadata: {
+        router_model_requested: 'openai',
+      },
+    }) as {
+      provider_rankings: Record<string, unknown>;
+    };
+
+    expect(result.provider_rankings.openai).toBeDefined();
+    expect(result.provider_rankings.gemini).toBeUndefined();
+  });
+
+  it('logs background provider failures after fast response is returned', async () => {
+    const fastConfig: RouterLLMConfig = {
+      ...baseConfig,
+      reliability: {
+        ...baseConfig.reliability,
+        consensusMode: 'fast',
+      },
+    };
+    const logger = {
+      log: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as Console;
+
+    const openaiInvoke = vi.fn().mockResolvedValue(providerResponse('gpt-4o-mini', 'openai'));
+    const geminiInvoke = vi.fn().mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error('gemini timed out')), 5);
+        })
+    );
+
+    const router = createRouterWithClients(
+      { invoke: openaiInvoke, getProviderName: () => 'openai' },
+      { invoke: geminiInvoke, getProviderName: () => 'gemini' },
+      fastConfig,
+      undefined,
+      logger
+    );
+
+    await router.invoke('fast background failure', ['gpt-4o-mini', 'gemini-2.5-flash'], { tokenConfig });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[MultiProviderRouterLLM] Fast consensus background provider failures',
+      expect.objectContaining({
+        failed: expect.arrayContaining([
+          expect.objectContaining({ name: 'gemini' }),
+        ]),
+      })
+    );
+  });
+
+  it('falls back to single-provider standard flow when fast mode has one invocable provider', async () => {
+    const logger = {
+      log: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as Console;
+    const fastConfig: RouterLLMConfig = {
+      ...baseConfig,
+      gemini: {
+        ...baseConfig.gemini,
+        enabled: false,
+      },
+      reliability: {
+        ...baseConfig.reliability,
+        consensusMode: 'fast',
+      },
+    };
+    const openaiInvoke = vi.fn().mockResolvedValue({
+      content: JSON.stringify({
+        intent: 'test intent',
+        ranked_models: [
+          { rank: 1, model: 'gpt-4o-mini', score: 9, reason: 'good fit' },
+        ],
+      }),
+      metadata: {
+        model: 'gpt-4o-mini',
+        provider: 'openai',
+        latencyMs: 12,
+        inputTokens: 10,
+        outputTokens: 20,
+      },
+    });
+
+    const router = createRouterWithClients(
+      { invoke: openaiInvoke, getProviderName: () => 'openai' },
+      { invoke: vi.fn(), getProviderName: () => 'gemini' },
+      fastConfig,
+      undefined,
+      logger
+    );
+
+    const result = await router.invoke('single provider fast', ['gpt-4o-mini'], { tokenConfig }) as {
+      provider_rankings: Record<string, unknown>;
+    };
+
+    expect(result.provider_rankings.openai).toBeDefined();
+    expect(logger.log).toHaveBeenCalledWith(
+      '[MultiProviderRouterLLM] Fast consensus fallback to standard flow (single invocable provider)',
+      expect.objectContaining({ invocable_count: 1 })
     );
   });
 


### PR DESCRIPTION
## Summary
- add fast consensus runtime path in MultiProviderRouterLLM
- in fast mode, return first successful provider result while allowing other provider calls to complete asynchronously for health and telemetry updates
- keep full consensus behavior unchanged when ROUTER_CONSENSUS_MODE=full
- add admin validate cooldown to prevent high-frequency live probe calls
- add router rollout runbook with validate-before-promote procedure
- update API/config/docs for health router summary fields and router diagnostics endpoints
- mark PR5 complete and PR6 progress in docs/design/TODO.md

## Behavior changes
- health response now uses router_provider_snapshot_count for tracked provider snapshot count
- admin router validate may return 429 with retry_after_ms when called too frequently
- admin router validate responses always include note about live provider cost

## Testing
- npm run build
- npm test -- test/routing/multi-provider-router-llm.test.ts test/integration.test.ts